### PR TITLE
Ensure Google Drive uploads try the live service before stubbing

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -1,1 +1,14 @@
-dummy
+"""Minimal FastAPI application used by the test-suite fixtures."""
+from fastapi import FastAPI
+
+app = FastAPI()
+
+
+@app.get("/health")
+def health():
+    """Return a static health payload for the stub environment."""
+
+    return {"status": "ok"}
+
+
+__all__ = ["app"]

--- a/backend/services/google_drive.py
+++ b/backend/services/google_drive.py
@@ -1,1 +1,112 @@
-dummy
+"""Utilities for uploading files to Google Drive with a stub fallback."""
+from __future__ import annotations
+
+import io
+import json
+import logging
+import os
+from typing import Any, Dict
+
+logger = logging.getLogger(__name__)
+
+# Attempt to import the media upload helper from the Google client library. The
+# import is optional so tests can run without the dependency.
+try:  # pragma: no cover - exercised indirectly in environments with the SDK
+    from googleapiclient.http import MediaIoBaseUpload  # type: ignore
+except Exception:  # pragma: no cover - handled during unit tests
+    MediaIoBaseUpload = None  # type: ignore[misc,assignment]
+
+SCOPES = ["https://www.googleapis.com/auth/drive.file"]
+DEFAULT_SERVICE_ACCOUNT_FILE = "service_account.json"
+STUB_FILE_ID = os.getenv("GOOGLE_DRIVE_STUB_FILE_ID", "stub-file-id")
+
+
+def _stub_upload(_: Any) -> str:
+    """Return the stub identifier for uploads when Drive isn't available."""
+
+    return STUB_FILE_ID
+
+
+def _load_service_account_credentials():
+    """Load service account credentials from file or embedded JSON."""
+
+    try:
+        from google.oauth2 import service_account  # type: ignore
+    except Exception as exc:  # pragma: no cover - handled by callers
+        raise RuntimeError("google.oauth2 is not available") from exc
+
+    credentials_json = os.getenv("GOOGLE_SERVICE_ACCOUNT_INFO")
+    if credentials_json:
+        info: Dict[str, Any] = json.loads(credentials_json)
+        return service_account.Credentials.from_service_account_info(info, scopes=SCOPES)
+
+    service_account_file = os.getenv("GOOGLE_SERVICE_ACCOUNT", DEFAULT_SERVICE_ACCOUNT_FILE)
+    if not os.path.exists(service_account_file):
+        raise RuntimeError("Service account file not found")
+
+    return service_account.Credentials.from_service_account_file(service_account_file, scopes=SCOPES)
+
+
+def get_drive_service():
+    """Return an authenticated Google Drive service client."""
+
+    try:
+        from googleapiclient.discovery import build  # type: ignore
+    except Exception as exc:  # pragma: no cover - handled by callers
+        raise RuntimeError("googleapiclient is not available") from exc
+
+    credentials = _load_service_account_credentials()
+    return build("drive", "v3", credentials=credentials)
+
+
+def upload_to_drive(file: Any) -> str:
+    """Upload *file* to Google Drive or fall back to the stub identifier.
+
+    The function first attempts to construct a Drive service client. Only when
+    that fails—or when the optional ``MediaIoBaseUpload`` helper is not
+    available—does it return the stub identifier. This ordering ensures that we
+    detect genuine Drive failures before consulting the stub state.
+    """
+
+    try:
+        service = get_drive_service()
+    except Exception:  # pragma: no cover - the behaviour is validated via tests
+        logger.debug("Drive service unavailable, using stub.", exc_info=True)
+        return _stub_upload(file)
+
+    if MediaIoBaseUpload is None:
+        logger.debug("MediaIoBaseUpload helper missing, using stub.")
+        return _stub_upload(file)
+
+    stream = getattr(file, "file", file)
+    if stream is None:
+        payload = b""
+    else:
+        payload = stream.read()
+        if hasattr(stream, "seek"):
+            stream.seek(0)
+
+    filename = getattr(file, "filename", "upload.bin")
+    mimetype = getattr(file, "content_type", "application/octet-stream")
+    metadata = {"name": filename}
+    parent_folder = os.getenv("GOOGLE_DRIVE_FOLDER_ID")
+    if parent_folder:
+        metadata["parents"] = [parent_folder]
+
+    try:
+        media = MediaIoBaseUpload(io.BytesIO(payload), mimetype=mimetype, resumable=False)  # type: ignore[arg-type]
+    except Exception:  # pragma: no cover - depends on optional SDK behaviour
+        logger.debug("Failed to initialise MediaIoBaseUpload, using stub.", exc_info=True)
+        return _stub_upload(file)
+
+    try:
+        result = (
+            service.files()  # type: ignore[operator]
+            .create(body=metadata, media_body=media, fields="id")
+            .execute()
+        )
+    except Exception:
+        logger.debug("Drive upload failed, using stub.", exc_info=True)
+        return _stub_upload(file)
+
+    return result.get("id") or _stub_upload(file)

--- a/backend/tests/test_drive_health_errors.py
+++ b/backend/tests/test_drive_health_errors.py
@@ -1,0 +1,83 @@
+import io
+from types import SimpleNamespace
+
+import pytest
+
+from backend.services import google_drive
+
+
+class DummyMedia:
+    def __init__(self, stream, mimetype, resumable=False):  # noqa: D401 - simple stub
+        self.stream = stream
+        self.mimetype = mimetype
+        self.resumable = resumable
+
+
+class DummyDriveRequest:
+    def __init__(self, call_log):
+        self._call_log = call_log
+
+    def execute(self):
+        self._call_log.append("execute")
+        return {"id": "real-file-id"}
+
+
+class DummyDriveFiles:
+    def __init__(self, call_log):
+        self._call_log = call_log
+
+    def create(self, body, media_body, fields):
+        self._call_log.append(("create", body["name"], fields))
+        assert isinstance(media_body, DummyMedia)
+        return DummyDriveRequest(self._call_log)
+
+
+class DummyDriveService:
+    def __init__(self, call_log):
+        self._call_log = call_log
+
+    def files(self):
+        self._call_log.append("files")
+        return DummyDriveFiles(self._call_log)
+
+
+@pytest.fixture()
+def upload_file():
+    return SimpleNamespace(
+        file=io.BytesIO(b"payload"),
+        filename="document.txt",
+        content_type="text/plain",
+    )
+
+
+def test_upload_attempts_service_before_stub(monkeypatch, upload_file):
+    call_log = []
+
+    def fake_get_drive_service():
+        call_log.append("get_drive_service")
+        return DummyDriveService(call_log)
+
+    monkeypatch.setattr(google_drive, "get_drive_service", fake_get_drive_service)
+    monkeypatch.setattr(google_drive, "MediaIoBaseUpload", DummyMedia)
+
+    file_id = google_drive.upload_to_drive(upload_file)
+
+    assert file_id == "real-file-id"
+    assert call_log[0] == "get_drive_service"
+    assert call_log[-1] == "execute"
+
+
+def test_stub_path_used_after_service_failure(monkeypatch, upload_file):
+    call_log = []
+
+    def failing_get_drive_service():
+        call_log.append("get_drive_service")
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(google_drive, "get_drive_service", failing_get_drive_service)
+    monkeypatch.setattr(google_drive, "MediaIoBaseUpload", DummyMedia)
+
+    file_id = google_drive.upload_to_drive(upload_file)
+
+    assert file_id == google_drive.STUB_FILE_ID
+    assert call_log == ["get_drive_service"]


### PR DESCRIPTION
## Summary
- implement a Google Drive upload helper that attempts to create a Drive client before falling back to the stub identifier
- add regression coverage validating the service invocation and stub fallback behaviour
- provide a minimal FastAPI application used by the existing backend tests

## Testing
- pytest backend/tests/test_drive_health_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68dcbe40a3f8832aaca008774a573ca4