### PR TITLE
Enrich Drive stub diagnostics for missing credentials

### DIFF
--- a/backend/api/drive_scan.py
+++ b/backend/api/drive_scan.py
@@ -1,17 +1,31 @@
 """Endpoints that surface Google Drive project folders to the UI."""
-from typing import Dict, List
+
+from typing import Any, Dict, List
+
 from fastapi import APIRouter
-from backend.services.google_drive import list_project_folders
+
+from backend.services import google_drive
 
 router = APIRouter()
 
 _KEYWORDS = ("villa", "tower", "phase", "building")
 
 @router.get("/projects/scan-drive")
-def scan_projects() -> Dict[str, List[str]]:
+def scan_projects() -> Dict[str, Any]:
     """Return a de-duplicated list of Drive folders that resemble projects."""
+    service = google_drive.get_drive_service()
+    if service is None:
+        return {
+            "status": "stubbed",
+            "projects": [],
+            "detail": google_drive.drive_service_error(),
+            "detail_source": google_drive.drive_service_error_source(),
+        }
+
     projects: List[str] = []
-    for drive_file in list_project_folders():
+    for drive_file in google_drive.list_project_folders(
+        service=service, lookup_service=False
+    ):
         name = drive_file.get("name", "")
         if any(keyword in name.lower() for keyword in _KEYWORDS):
             projects.append(name)
@@ -22,4 +36,4 @@ def scan_projects() -> Dict[str, List[str]]:
         if project not in seen:
             deduped.append(project)
             seen.add(project)
-    return {"projects": deduped}
+    return {"status": "ok", "projects": deduped}

--- a/backend/api/speech.py
+++ b/backend/api/speech.py
@@ -1,8 +1,27 @@
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, File, UploadFile
+
+from backend.services import google_drive
 
 router = APIRouter()
 
+
 @router.post("/speech")
 async def speech_to_text(file: UploadFile = File(...)):
-    # Stub implementation
-    return {"text": "transcribed text (stub)"}
+    """Transcribe audio and upload artefacts when Drive is available."""
+
+    service = google_drive.get_drive_service()
+    if service is None:
+        return {
+            "status": "stubbed",
+            "text": "transcribed text (stub)",
+            "file_id": google_drive.upload_to_drive(file, lookup_service=False),
+            "detail": google_drive.drive_service_error(),
+            "detail_source": google_drive.drive_service_error_source(),
+        }
+
+    file_id = google_drive.upload_to_drive(file, service=service, lookup_service=False)
+    return {
+        "status": "ok",
+        "text": "transcribed text (demo)",
+        "file_id": file_id,
+    }

--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -1,8 +1,23 @@
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, File, UploadFile
+
+from backend.services import google_drive
 
 router = APIRouter()
 
+
 @router.post("/upload")
 async def upload_file(file: UploadFile = File(...)):
-    # Stub implementation
-    return {"filename": file.filename, "status": "uploaded"}
+    """Upload a file to Drive or return a stubbed identifier."""
+
+    service = google_drive.get_drive_service()
+    if service is None:
+        return {
+            "status": "stubbed",
+            "file_id": google_drive.upload_to_drive(file, lookup_service=False),
+            "filename": file.filename,
+            "detail": google_drive.drive_service_error(),
+            "detail_source": google_drive.drive_service_error_source(),
+        }
+
+    file_id = google_drive.upload_to_drive(file, service=service, lookup_service=False)
+    return {"status": "ok", "file_id": file_id, "filename": file.filename}

--- a/backend/api/vision.py
+++ b/backend/api/vision.py
@@ -1,8 +1,28 @@
-from fastapi import APIRouter, UploadFile, File
+from fastapi import APIRouter, File, UploadFile
+
+from backend.services import google_drive
 
 router = APIRouter()
 
+
 @router.post("/vision")
 async def analyze_image(file: UploadFile = File(...)):
-    # Stub implementation
-    return {"detections": []}
+    """Analyse an image and optionally store the artefact on Drive."""
+
+    service = google_drive.get_drive_service()
+    detections = []
+    if service is None:
+        return {
+            "status": "stubbed",
+            "detections": detections,
+            "file_id": google_drive.upload_to_drive(file, lookup_service=False),
+            "detail": google_drive.drive_service_error(),
+            "detail_source": google_drive.drive_service_error_source(),
+        }
+
+    file_id = google_drive.upload_to_drive(file, service=service, lookup_service=False)
+    return {
+        "status": "ok",
+        "detections": detections,
+        "file_id": file_id,
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,25 +1,70 @@
 import os
+
 from fastapi import FastAPI
-from backend.api import users, projects, alerts, drive_scan, drive_diagnose, preferences
+
+from backend.api import (
+    alerts,
+    drive_diagnose,
+    drive_scan,
+    preferences,
+    projects,
+    speech,
+    upload,
+    users,
+    vision,
+)
+from backend.services import google_drive
 
 app = FastAPI(title="Diriyah Brain AI")
 
 # Routers
 app.include_router(users.router, prefix="/api")
-app.include_router(projects.router, prefix="/api")
-app.include_router(alerts.router, prefix="/api")
 app.include_router(drive_scan.router, prefix="/api")
 app.include_router(drive_diagnose.router, prefix="/api")
+app.include_router(projects.router, prefix="/api")
+app.include_router(alerts.router, prefix="/api")
 app.include_router(preferences.router, prefix="/api")
+app.include_router(upload.router, prefix="/api")
+app.include_router(speech.router, prefix="/api")
+app.include_router(vision.router, prefix="/api")
 
 @app.get("/health")
 def health():
-    return {"status": "ok"}
+    """Expose a lightweight health payload with Drive diagnostics."""
+
+    credentials_available = google_drive.drive_credentials_available()
+    service_error = google_drive.drive_service_error()
+    service_error_source = google_drive.drive_service_error_source()
+    return {
+        "status": "ok",
+        "drive": {
+            "credentials_available": credentials_available,
+            "service_error": service_error,
+            "service_error_source": service_error_source,
+            "stubbed": (not credentials_available) or (service_error is not None),
+        },
+    }
 
 @app.on_event("startup")
-async def log_project_mode():
+async def log_startup_state() -> None:
+    """Emit startup diagnostics that help with Render debugging."""
+
     mode = "FIXTURE" if os.getenv("USE_FIXTURE_PROJECTS", "true").lower() == "true" else "GOOGLE DRIVE"
     print(f"📂 Project API running in {mode} mode")
+
+    credentials_available = google_drive.drive_credentials_available()
+    service_error = google_drive.drive_service_error()
+    service_error_source = google_drive.drive_service_error_source()
+    stubbed = (not credentials_available) or (service_error is not None)
+
+    drive_mode = "STUBBED" if stubbed else "LIVE"
+    print(
+        "📁 Google Drive integration: %s (credentials_available=%s, error_source=%s)"
+        % (drive_mode, credentials_available, service_error_source)
+    )
+
+    if service_error:
+        print(f"   ↳ Drive service error: {service_error}")
 
 # Keep this literal for tests:
 # app.include_router(users.router ...

--- a/backend/services/google_drive.py
+++ b/backend/services/google_drive.py
@@ -1,15 +1,194 @@
-def get_drive_service():
-    class _About:
-        def get(self, fields=None):
-            return self
-        def execute(self):
-            return {"user": {"emailAddress": "stub@example.com", "displayName": "Stub"}}
-    class _Service:
-        def about(self): return _About()
-    return _Service()
+"""Google Drive helper functions with graceful stub fallbacks."""
 
-def list_project_folders():
-    return [{"name": "Gateway1", "mimeType": "application/vnd.google-apps.folder"}]
+from __future__ import annotations
 
-def get_project(project_id: str):
-    return {"id": project_id, "name": f"Project {project_id}", "drive_id": "stub"}
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+__all__ = (
+    "drive_credentials_available",
+    "drive_service_error",
+    "drive_service_error_source",
+    "get_drive_service",
+    "get_project",
+    "list_project_folders",
+    "upload_to_drive",
+)
+
+if TYPE_CHECKING:  # pragma: no cover - hinting only
+    from fastapi import UploadFile
+else:  # pragma: no cover - runtime fallback when FastAPI not available
+    UploadFile = Any  # type: ignore[misc,assignment]
+
+DRIVE_SCOPE = "https://www.googleapis.com/auth/drive"
+
+STUB_FILE_ID = "stub-file-0001"
+STUB_FOLDERS: List[Dict[str, str]] = [
+    {
+        "id": "stub-folder-001",
+        "name": "Gateway District Phase 1",
+        "mimeType": "application/vnd.google-apps.folder",
+    },
+    {
+        "id": "stub-folder-002",
+        "name": "Bujairi Terrace Expansion",
+        "mimeType": "application/vnd.google-apps.folder",
+    },
+]
+
+_last_service_error: Optional[str] = None
+_last_service_error_source: Optional[str] = None
+
+
+def _credentials_path(*, record_errors: bool = False) -> Optional[Path]:
+    """Return the credentials path if the environment is configured."""
+
+    env_value = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if not env_value:
+        if record_errors:
+            _record_service_error("GOOGLE_APPLICATION_CREDENTIALS is not set", source="credentials")
+        return None
+
+    candidate = Path(env_value).expanduser()
+
+    if not candidate.exists():
+        if record_errors:
+            _record_service_error(f"Credentials file not found: {candidate}", source="credentials")
+        return None
+
+    if not candidate.is_file():
+        if record_errors:
+            _record_service_error(f"Credentials path is not a file: {candidate}", source="credentials")
+        return None
+
+    if not os.access(candidate, os.R_OK):
+        if record_errors:
+            _record_service_error(f"Credentials file is not readable: {candidate}", source="credentials")
+        return None
+
+    if record_errors and _last_service_error_source == "credentials":
+        _record_service_error(None)
+
+    return candidate
+
+
+def drive_credentials_available() -> bool:
+    """Return ``True`` when credentials exist and are readable."""
+
+    return _credentials_path(record_errors=True) is not None
+
+
+def drive_service_error() -> Optional[str]:
+    """Return the last recorded service error, if any."""
+
+    return _last_service_error
+
+
+def drive_service_error_source() -> Optional[str]:
+    """Return the origin of the last recorded service error."""
+
+    return _last_service_error_source
+
+
+def _record_service_error(reason: Optional[str], *, source: str = "service") -> None:
+    global _last_service_error, _last_service_error_source
+    _last_service_error = reason
+    _last_service_error_source = source if reason is not None else None
+
+
+def get_drive_service() -> Any | None:
+    """Return a Google Drive service or ``None`` when unavailable."""
+
+    credentials_path = _credentials_path(record_errors=True)
+    if not credentials_path:
+        return None
+
+    try:
+        from google.oauth2 import service_account  # type: ignore
+        from googleapiclient.discovery import build  # type: ignore
+    except Exception as exc:  # pragma: no cover - requires optional dependency
+        logger.warning("Google Drive libraries unavailable: %s", exc)
+        _record_service_error(str(exc), source="initialisation")
+        return None
+
+    try:
+        credentials = service_account.Credentials.from_service_account_file(
+            str(credentials_path), scopes=[DRIVE_SCOPE]
+        )
+        service = build("drive", "v3", credentials=credentials, cache_discovery=False)
+        _record_service_error(None)
+        return service
+    except Exception as exc:  # pragma: no cover - defensive, depends on Google client
+        logger.warning("Failed to initialise Google Drive service: %s", exc)
+        _record_service_error(str(exc), source="initialisation")
+        return None
+
+
+def upload_to_drive(
+    file_obj: "UploadFile",
+    *,
+    service: Any | None = None,
+    lookup_service: bool = True,
+) -> str:
+    """Upload a file to Drive or return a deterministic stub identifier."""
+
+    if service is None and lookup_service:
+        service = get_drive_service()
+    if service is None:
+        return STUB_FILE_ID
+
+    try:  # pragma: no cover - exercised only with Google client available
+        from googleapiclient.http import MediaIoBaseUpload  # type: ignore
+
+        metadata = {"name": getattr(file_obj, "filename", "upload.bin")}
+        media = MediaIoBaseUpload(
+            file_obj.file, mimetype=getattr(file_obj, "content_type", None), resumable=False
+        )
+        response = (
+            service.files()
+            .create(body=metadata, media_body=media, fields="id")
+            .execute()
+        )
+        return response.get("id", STUB_FILE_ID)
+    except Exception as exc:
+        logger.warning("Drive upload failed, returning stub identifier: %s", exc)
+        return STUB_FILE_ID
+
+
+def list_project_folders(
+    *, service: Any | None = None, lookup_service: bool = True
+) -> List[Dict[str, Any]]:
+    """List project folders from Drive or return stub fixtures."""
+
+    if service is None and lookup_service:
+        service = get_drive_service()
+    if service is None:
+        return [folder.copy() for folder in STUB_FOLDERS]
+
+    try:  # pragma: no cover - exercised only with Google client available
+        response = (
+            service.files()
+            .list(
+                q="mimeType='application/vnd.google-apps.folder' and trashed=false",
+                fields="files(id,name,mimeType)",
+            )
+            .execute()
+        )
+        return response.get("files", [])
+    except Exception as exc:
+        logger.warning("Drive list failed, returning stub folders: %s", exc)
+        return list(STUB_FOLDERS)
+
+
+def get_project(project_id: str) -> Dict[str, str]:
+    """Return stub project metadata."""
+
+    return {
+        "id": project_id,
+        "name": f"Project {project_id}",
+        "drive_id": "stub",
+    }

--- a/backend/tests/test_drive_stubbed_endpoints.py
+++ b/backend/tests/test_drive_stubbed_endpoints.py
@@ -1,0 +1,108 @@
+"""Regression coverage for stubbed Google Drive behaviour."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Generator
+
+import pytest
+from fastapi.testclient import TestClient
+
+from backend.api import projects
+from backend.main import app
+from backend.services import google_drive
+
+
+@pytest.fixture()
+def stubbed_client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient, None, None]:
+    """Return a client with Google credentials pointing to a missing file."""
+
+    missing_path = Path("/tmp/google-credentials-missing.json")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", str(missing_path))
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_health_reports_missing_credentials(stubbed_client: TestClient) -> None:
+    response = stubbed_client.get("/health")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["drive"]["credentials_available"] is False
+    # service_error should be recorded even before any Drive call
+    assert "Credentials" in payload["drive"]["service_error"]
+    assert payload["drive"]["service_error_source"] == "credentials"
+    assert payload["drive"]["stubbed"] is True
+
+
+def test_upload_endpoint_stubbed(stubbed_client: TestClient) -> None:
+    response = stubbed_client.post(
+        "/api/upload",
+        files={"file": ("demo.txt", b"hello", "text/plain")},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["file_id"] == google_drive.STUB_FILE_ID
+    assert payload["detail"] == google_drive.drive_service_error()
+    assert payload["detail_source"] == google_drive.drive_service_error_source()
+
+
+def test_speech_endpoint_stubbed(stubbed_client: TestClient) -> None:
+    response = stubbed_client.post(
+        "/api/speech",
+        files={"file": ("voice.wav", b"audio-bytes", "audio/wav")},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["file_id"] == google_drive.STUB_FILE_ID
+    assert "text" in payload
+    assert payload["detail"] == google_drive.drive_service_error()
+    assert payload["detail_source"] == google_drive.drive_service_error_source()
+
+
+def test_vision_endpoint_stubbed(stubbed_client: TestClient) -> None:
+    response = stubbed_client.post(
+        "/api/vision",
+        files={"file": ("image.png", b"png-bytes", "image/png")},
+    )
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["file_id"] == google_drive.STUB_FILE_ID
+    assert payload["detections"] == []
+    assert payload["detail"] == google_drive.drive_service_error()
+    assert payload["detail_source"] == google_drive.drive_service_error_source()
+
+
+def test_projects_endpoint_stubbed(monkeypatch: pytest.MonkeyPatch, stubbed_client: TestClient) -> None:
+    monkeypatch.setattr(projects, "USE_FIXTURE_PROJECTS", False)
+    response = stubbed_client.get("/api/projects")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["projects"] == google_drive.STUB_FOLDERS
+    assert payload["detail"] == google_drive.drive_service_error()
+    assert payload["detail_source"] == google_drive.drive_service_error_source()
+
+
+def test_drive_scan_endpoint_stubbed(stubbed_client: TestClient) -> None:
+    response = stubbed_client.get("/api/projects/scan-drive")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["projects"] == []
+    assert payload["detail"] == google_drive.drive_service_error()
+    assert payload["detail_source"] == google_drive.drive_service_error_source()
+
+
+def test_drive_diagnose_endpoint_stubbed(stubbed_client: TestClient) -> None:
+    response = stubbed_client.get("/api/drive/diagnose")
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["projects"] == google_drive.STUB_FOLDERS
+    assert payload["detail"] == google_drive.drive_service_error()
+    assert payload["detail_source"] == google_drive.drive_service_error_source()
+    assert payload["credentials_available"] is False

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -22,13 +22,17 @@ def test_fixture_mode_enabled() -> None:
 def test_list_projects_returns_fixture_order() -> None:
     response = client.get("/api/projects")
     assert response.status_code == 200
-    assert response.json() == list(projects.PROJECT_FIXTURES.values())
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["projects"] == list(projects.PROJECT_FIXTURES.values())
 
 def test_get_project_returns_expected_stub() -> None:
     project_id, project_stub = next(iter(projects.PROJECT_FIXTURES.items()))
     response = client.get(f"/api/projects/{project_id}")
     assert response.status_code == 200
-    assert response.json() == project_stub
+    payload = response.json()
+    assert payload["status"] == "stubbed"
+    assert payload["project"] == project_stub
 
 def test_get_project_unknown_id_returns_404() -> None:
     response = client.get("/api/projects/unknown")


### PR DESCRIPTION
## Summary
- export Drive helper functions and ensure stub folders are returned as fresh copies
- add detailed stub responses (including credential flags) across Drive-dependent endpoints for easier debugging
- extend regression coverage to assert the new diagnostic fields when credentials are missing
- surface Drive credential availability in the `/health` endpoint for Render debugging
- record credential file errors during health checks so service diagnostics show up before any Drive call
- preserve previously recorded Drive service errors when credential checks succeed so `/health` continues reporting non-credential failures
- log Google Drive startup diagnostics so Render logs immediately show stub mode and any recorded errors
- expose Drive error sources in stubbed responses and health checks so Render logs and APIs highlight whether failures came from credentials or initialisation

## Testing
- pytest backend/tests -q

------
https://chatgpt.com/codex/tasks/task_e_68da7d59872c832a9bc747d13af775b8