### PR TITLE
Refine Drive stubbed detection

### DIFF
--- a/backend/api/projects.py
+++ b/backend/api/projects.py
@@ -1,1 +1,30 @@
-dummy
+from __future__ import annotations
+
+from typing import List
+
+from fastapi import APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+
+class ProjectStub(BaseModel):
+    """Minimal project representation used for local development."""
+
+    id: int
+    name: str
+    status: str
+
+
+_PROJECTS: List[ProjectStub] = [
+    ProjectStub(id=1, name="Gateway Villas", status="active"),
+    ProjectStub(id=2, name="Downtown Towers", status="planning"),
+    ProjectStub(id=3, name="Cultural District", status="on-hold"),
+]
+
+
+@router.get("/projects", response_model=List[ProjectStub])
+def list_projects() -> List[ProjectStub]:
+    """Return a deterministic set of stubbed projects for the UI."""
+
+    return _PROJECTS

--- a/backend/api/upload.py
+++ b/backend/api/upload.py
@@ -1,1 +1,16 @@
-dummy
+from __future__ import annotations
+
+from fastapi import APIRouter, File, UploadFile
+
+router = APIRouter()
+
+
+@router.post("/upload")
+async def upload_stub(file: UploadFile = File(...)) -> dict[str, object]:
+    """Return metadata about an uploaded file without persisting it."""
+
+    content = await file.read()
+    size = len(content)
+    # Reset the read pointer so other code paths can re-read the file if needed.
+    await file.seek(0)
+    return {"filename": file.filename, "size": size, "status": "stubbed"}

--- a/backend/api/vision.py
+++ b/backend/api/vision.py
@@ -1,1 +1,12 @@
-dummy
+from __future__ import annotations
+
+from fastapi import APIRouter
+
+router = APIRouter()
+
+
+@router.get("/vision/diagnostics")
+def vision_diagnostics() -> dict[str, str]:
+    """Return a stubbed response indicating the vision pipeline is mocked."""
+
+    return {"status": "stubbed", "detail": "Vision pipeline not available in tests"}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,1 +1,55 @@
-dummy
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from backend.api import (
+    alerts,
+    cache,
+    chat,
+    drive,
+    drive_diagnose,
+    drive_scan,
+    openai_test,
+    preferences,
+    project,
+    projects,
+    speech,
+    upload,
+    users,
+    vision,
+)
+from backend.services.google_drive import (
+    drive_credentials_available,
+    drive_service_error,
+    drive_stubbed,
+)
+
+app = FastAPI(title="Diriyah Brain AI", version="v1.24")
+app.add_middleware(CORSMiddleware, allow_origins=["*"], allow_credentials=True, allow_methods=["*"], allow_headers=["*"])
+
+app.include_router(chat.router, prefix="/api", tags=["Chat"])
+app.include_router(project.router, prefix="/api", tags=["Intel"])
+app.include_router(cache.router, prefix="/api", tags=["Cache"])
+app.include_router(alerts.router, prefix="/api", tags=["Alerts"])
+app.include_router(drive.router, prefix="/api", tags=["Drive"])
+app.include_router(openai_test.router, prefix="/api", tags=["OpenAI"])
+app.include_router(upload.router, prefix="/api", tags=["Upload"])
+app.include_router(vision.router, prefix="/api", tags=["Vision"])
+app.include_router(speech.router, prefix="/api", tags=["Speech"])
+app.include_router(projects.router, prefix="/api", tags=["Projects"])
+app.include_router(preferences.router, prefix="/api", tags=["Preferences"])
+app.include_router(drive_scan.router, prefix="/api", tags=["Drive"])
+app.include_router(drive_diagnose.router, prefix="/api", tags=["Drive"])
+app.include_router(users.router, prefix="/api", tags=["Users"])
+
+
+@app.get("/health")
+def health_check():
+    error = drive_service_error()
+    return {
+        "status": "ok" if error is None else "degraded",
+        "version": "v1.24",
+        "drive": {
+            "credentials_available": drive_credentials_available(),
+            "stubbed": drive_stubbed(),
+            "error": error,
+        },
+    }

--- a/backend/services/google_drive.py
+++ b/backend/services/google_drive.py
@@ -1,1 +1,253 @@
-dummy
+"""Utilities and stubs for interacting with Google Drive.
+
+This module provides a very small abstraction layer that the rest of the
+application interacts with.  When the real Google client libraries are
+available we attempt to build a Drive service using the configured service
+account file.  When the libraries or credentials are unavailable we fall back
+ to deterministic stubbed responses that are convenient for local development
+and unit tests.
+
+The public helpers intentionally track a bit of internal state so that
+observability surfaces (notably the ``/health`` endpoint) can show whether the
+service is running in stubbed mode as well as the most recent error that
+prevented the real integration from initialising.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+from pathlib import Path
+from threading import Lock
+from typing import Any, Dict, Iterable, List, Optional
+
+try:  # pragma: no cover - exercised indirectly via tests that patch imports
+    from google.oauth2 import service_account  # type: ignore
+    from googleapiclient.discovery import build  # type: ignore
+    from googleapiclient.http import MediaIoBaseUpload  # type: ignore
+except Exception as import_exc:  # pragma: no cover - handled in tests
+    service_account = None  # type: ignore[assignment]
+    build = None  # type: ignore[assignment]
+    MediaIoBaseUpload = None  # type: ignore[assignment]
+    _IMPORT_ERROR: Optional[BaseException] = import_exc
+else:
+    _IMPORT_ERROR = None
+
+_DRIVE_SCOPES = ["https://www.googleapis.com/auth/drive"]
+_CREDENTIAL_ENV_VAR = "GOOGLE_SERVICE_ACCOUNT"
+_DEFAULT_CREDENTIAL_FILE = "service_account.json"
+
+_STATE_LOCK = Lock()
+_drive_service: Any = None
+_service_ready = False
+_credentials_available = False
+_credential_error: Optional[str] = None
+_last_service_error: Optional[str] = None
+_last_error_source: Optional[str] = None
+
+_STUB_FOLDERS: List[Dict[str, str]] = [
+    {
+        "id": "stub-folder-gateway",
+        "name": "Gateway Villas Phase 1",
+        "mimeType": "application/vnd.google-apps.folder",
+    },
+    {
+        "id": "stub-folder-towers",
+        "name": "Downtown Towers",
+        "mimeType": "application/vnd.google-apps.folder",
+    },
+    {
+        "id": "stub-folder-infra",
+        "name": "Infrastructure Package",
+        "mimeType": "application/vnd.google-apps.folder",
+    },
+]
+
+
+def _display_path(path: Path) -> str:
+    """Return a friendly representation of ``path`` for error messages."""
+
+    try:
+        return str(path.resolve())
+    except FileNotFoundError:  # pragma: no cover - defensive fallback
+        return str(path.absolute())
+
+
+def _record_error(message: str, *, source: str) -> None:
+    """Persist ``message`` as the latest Drive integration error."""
+
+    global _last_service_error, _last_error_source, _service_ready, _drive_service
+    with _STATE_LOCK:
+        _last_service_error = message
+        _last_error_source = source
+        _service_ready = False
+        _drive_service = None
+
+
+def _update_credentials_state(path: Path) -> None:
+    """Update bookkeeping related to credential availability."""
+
+    global _credentials_available, _credential_error, _last_service_error, _last_error_source
+    exists = path.exists()
+    message: Optional[str] = None
+    if not exists:
+        message = f"Google Drive credentials not found at {_display_path(path)}"
+    with _STATE_LOCK:
+        _credentials_available = exists
+        _credential_error = message
+        if exists:
+            if _last_error_source == "credentials":
+                _last_service_error = None
+                _last_error_source = None
+        else:
+            _last_service_error = message
+            _last_error_source = "credentials"
+            _service_ready = False
+            _drive_service = None
+
+
+def _credentials_path() -> Path:
+    """Return the configured path to the service account file."""
+
+    candidate = os.getenv(_CREDENTIAL_ENV_VAR, _DEFAULT_CREDENTIAL_FILE)
+    path = Path(candidate).expanduser()
+    _update_credentials_state(path)
+    return path
+
+
+def drive_credentials_available() -> bool:
+    """Return ``True`` when the configured credentials file exists."""
+
+    _credentials_path()
+    with _STATE_LOCK:
+        return _credentials_available
+
+
+def drive_service_error() -> Optional[str]:
+    """Return the most recent error encountered initialising the service."""
+
+    with _STATE_LOCK:
+        return _last_service_error
+
+
+def drive_stubbed() -> bool:
+    """Return ``True`` when the Drive integration is operating in stub mode."""
+
+    with _STATE_LOCK:
+        return not (_service_ready and _credentials_available)
+
+
+def _initialise_service() -> Any:
+    """Construct and cache a Google Drive service instance."""
+
+    if _IMPORT_ERROR is not None or service_account is None or build is None:
+        message = f"Google Drive client libraries unavailable: {_IMPORT_ERROR!s}"
+        _record_error(message, source="import")
+        raise RuntimeError(message) from _IMPORT_ERROR
+
+    credentials_path = _credentials_path()
+    with _STATE_LOCK:
+        credentials_ok = _credentials_available
+        credential_problem = _credential_error
+    if not credentials_ok:
+        raise RuntimeError(credential_problem or "Google Drive credentials missing")
+
+    try:
+        credentials = service_account.Credentials.from_service_account_file(  # type: ignore[union-attr]
+            str(credentials_path), scopes=_DRIVE_SCOPES
+        )
+        service = build("drive", "v3", credentials=credentials, cache_discovery=False)
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        message = f"Failed to initialise Google Drive service: {exc}"
+        _record_error(message, source="initialise")
+        raise RuntimeError(message) from exc
+
+    with _STATE_LOCK:
+        global _drive_service, _service_ready, _last_service_error, _last_error_source
+        _drive_service = service
+        _service_ready = True
+        if _last_error_source != "credentials":
+            _last_service_error = None
+            _last_error_source = None
+    return service
+
+
+def get_drive_service() -> Any:
+    """Return a Google Drive service or raise ``RuntimeError`` on failure."""
+
+    with _STATE_LOCK:
+        if _service_ready and _drive_service is not None:
+            return _drive_service
+    return _initialise_service()
+
+
+def list_project_folders() -> List[Dict[str, Any]]:
+    """List folders from Google Drive, falling back to stub data on failure."""
+
+    try:
+        service = get_drive_service()
+    except RuntimeError:
+        return list(_STUB_FOLDERS)
+
+    try:
+        response = (
+            service.files()
+            .list(
+                q="mimeType='application/vnd.google-apps.folder' and trashed=false",
+                fields="files(id,name,mimeType)",
+                pageSize=200,
+            )
+            .execute()
+        )
+    except Exception as exc:  # pragma: no cover - defensive network error path
+        _record_error(f"Failed to list Google Drive folders: {exc}", source="list")
+        return list(_STUB_FOLDERS)
+
+    files = response.get("files", [])
+    if isinstance(files, Iterable):
+        return list(files)
+    return list(_STUB_FOLDERS)
+
+
+def upload_to_drive(file_obj: Any) -> str:
+    """Upload ``file_obj`` to Drive or return a stub identifier when stubbed."""
+
+    try:
+        service = get_drive_service()
+    except RuntimeError:
+        return "stubbed-upload-id"
+
+    if MediaIoBaseUpload is None:
+        return "stubbed-upload-id"
+
+    if hasattr(file_obj, "file"):
+        content = file_obj.file.read()
+        file_obj.file.seek(0)
+        filename = getattr(file_obj, "filename", "upload.bin")
+        content_type = getattr(file_obj, "content_type", "application/octet-stream")
+    else:
+        content = getattr(file_obj, "read", lambda: b"")()
+        filename = getattr(file_obj, "name", "upload.bin")
+        content_type = getattr(file_obj, "content_type", "application/octet-stream")
+
+    media = MediaIoBaseUpload(io.BytesIO(content), mimetype=content_type, resumable=False)
+    metadata: Dict[str, Any] = {"name": filename}
+
+    try:
+        response = (
+            service.files()
+            .create(body=metadata, media_body=media, fields="id")
+            .execute()
+        )
+    except Exception as exc:  # pragma: no cover - defensive network error path
+        _record_error(f"Failed to upload file to Google Drive: {exc}", source="upload")
+        return "stubbed-upload-id"
+
+    return str(response.get("id", "stubbed-upload-id"))
+
+
+if _IMPORT_ERROR is not None:  # pragma: no cover - import failure tested indirectly
+    _record_error(
+        f"Google Drive client libraries unavailable: {_IMPORT_ERROR!s}",
+        source="import",
+    )

--- a/backend/tests/test_drive_health_errors.py
+++ b/backend/tests/test_drive_health_errors.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+import importlib
+import io
+import sys
+import types
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _install_fake_google_modules() -> dict[str, types.ModuleType | None]:
+    """Inject minimal fake Google client modules for testing."""
+
+    build_error = RuntimeError("build exploded")
+
+    google_pkg = types.ModuleType("google")
+    google_pkg.__path__ = []  # type: ignore[attr-defined]
+    oauth2_module = types.ModuleType("google.oauth2")
+    service_account_module = types.ModuleType("google.oauth2.service_account")
+
+    class _FakeCredentials:
+        @classmethod
+        def from_service_account_file(cls, *args, **kwargs):  # type: ignore[no-untyped-def]
+            return object()
+
+    service_account_module.Credentials = _FakeCredentials  # type: ignore[attr-defined]
+    oauth2_module.service_account = service_account_module  # type: ignore[attr-defined]
+    google_pkg.oauth2 = oauth2_module  # type: ignore[attr-defined]
+
+    googleapiclient_pkg = types.ModuleType("googleapiclient")
+    googleapiclient_pkg.__path__ = []  # type: ignore[attr-defined]
+    discovery_module = types.ModuleType("googleapiclient.discovery")
+
+    def _failing_build(*args, **kwargs):  # type: ignore[no-untyped-def]
+        raise build_error
+
+    discovery_module.build = _failing_build  # type: ignore[attr-defined]
+    http_module = types.ModuleType("googleapiclient.http")
+
+    class _FakeUpload:  # pragma: no cover - simple stub
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+    http_module.MediaIoBaseUpload = _FakeUpload  # type: ignore[attr-defined]
+    googleapiclient_pkg.discovery = discovery_module  # type: ignore[attr-defined]
+    googleapiclient_pkg.http = http_module  # type: ignore[attr-defined]
+
+    injected = {
+        "google": google_pkg,
+        "google.oauth2": oauth2_module,
+        "google.oauth2.service_account": service_account_module,
+        "googleapiclient": googleapiclient_pkg,
+        "googleapiclient.discovery": discovery_module,
+        "googleapiclient.http": http_module,
+    }
+
+    previous: dict[str, types.ModuleType | None] = {}
+    for name, module in injected.items():
+        previous[name] = sys.modules.get(name)
+        sys.modules[name] = module
+    return previous
+
+
+def _restore_modules(previous: dict[str, types.ModuleType | None]) -> None:
+    """Restore modules that were temporarily replaced during the test."""
+
+    for name, module in previous.items():
+        if module is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = module
+
+
+@pytest.mark.usefixtures("tmp_path")
+def test_health_reports_non_credential_drive_error(monkeypatch, tmp_path):
+    """Ensure credential checks do not clear non-credential Drive errors."""
+
+    credential_file = Path(tmp_path) / "service_account.json"
+    credential_file.write_text("{}", encoding="utf-8")
+    monkeypatch.setenv("GOOGLE_SERVICE_ACCOUNT", str(credential_file))
+
+    import backend.services.google_drive as google_drive_module
+    import backend.main as backend_main_module
+
+    previous_modules = _install_fake_google_modules()
+
+    try:
+        google_drive = importlib.reload(google_drive_module)
+        backend_main = importlib.reload(backend_main_module)
+
+        with pytest.raises(RuntimeError):
+            google_drive.get_drive_service()
+
+        # Credential probes should not wipe the recorded non-credential error.
+        assert google_drive.drive_credentials_available() is True
+        assert google_drive.drive_service_error() is not None
+        assert google_drive.drive_credentials_available() is True
+        recorded_error = google_drive.drive_service_error()
+        assert recorded_error is not None and "build exploded" in recorded_error
+
+        with TestClient(backend_main.app) as client:
+            response = client.get("/health")
+        payload = response.json()
+        assert payload["drive"]["credentials_available"] is True
+        assert payload["drive"]["stubbed"] is True
+        assert "build exploded" in (payload["drive"].get("error") or "")
+    finally:
+        _restore_modules(previous_modules)
+        importlib.reload(google_drive_module)
+        importlib.reload(backend_main_module)
+
+
+def test_upload_attempts_to_initialise_drive_service(monkeypatch):
+    """Ensure uploads try to build the Drive service before using the stub."""
+
+    import backend.services.google_drive as google_drive_module
+
+    google_drive = importlib.reload(google_drive_module)
+
+    call_count = 0
+
+    def _failing_get_drive_service():  # type: ignore[no-untyped-def]
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("boom")
+
+    class _FakeUpload:  # pragma: no cover - trivial shim for instantiation
+        def __init__(self, *args, **kwargs):  # type: ignore[no-untyped-def]
+            pass
+
+    monkeypatch.setattr(google_drive, "get_drive_service", _failing_get_drive_service)
+    monkeypatch.setattr(google_drive, "MediaIoBaseUpload", _FakeUpload)
+
+    try:
+        result = google_drive.upload_to_drive(io.BytesIO(b"payload"))
+    finally:
+        importlib.reload(google_drive_module)
+
+    assert result == "stubbed-upload-id"
+    assert call_count == 1

--- a/backend/tests/test_drive_stubbed_endpoints.py
+++ b/backend/tests/test_drive_stubbed_endpoints.py
@@ -1,1 +1,24 @@
-dummy
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.main import app
+
+
+def test_drive_scan_returns_stubbed_projects() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/projects/scan-drive")
+        assert response.status_code == 200
+        payload = response.json()
+    assert "projects" in payload
+    assert isinstance(payload["projects"], list)
+    assert payload["projects"], "expected stubbed projects to be returned"
+
+
+def test_drive_diagnose_reports_error_when_stubbed() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/drive/diagnose")
+        assert response.status_code == 200
+        payload = response.json()
+    assert payload.get("status") == "error"
+    assert "detail" in payload

--- a/backend/tests/test_projects.py
+++ b/backend/tests/test_projects.py
@@ -1,1 +1,15 @@
-dummy
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+from backend.api.projects import _PROJECTS
+from backend.main import app
+
+
+def test_projects_endpoint_returns_stubbed_payload() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/projects")
+        assert response.status_code == 200
+        payload = response.json()
+    expected = [project.model_dump() for project in _PROJECTS]
+    assert payload == expected


### PR DESCRIPTION
## Summary
- ensure the Drive stubbed flag now requires both credential availability and a ready service so health reporting reflects either missing credentials or initialisation failures

## Testing
- pytest backend/tests/test_drive_health_errors.py backend/tests/test_health.py

------
https://chatgpt.com/codex/tasks/task_e_68db977a9b68832a86e8f1229824bd74