### PR TITLE
Remove Alembic from Render start command

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -5,7 +5,7 @@ services:
     plan: starter
     branch: main
     buildCommand: docker build -t mba-backend .
-    startCommand: bash -c "alembic upgrade head && uvicorn backend.main:app --host 0.0.0.0 --port 8000"
+    startCommand: bash -c "uvicorn backend.main:app --host 0.0.0.0 --port 8000"
     envVars:
       - key: OPENAI_API_KEY
         sync: false


### PR DESCRIPTION
## Summary
- update the Render service start command to run uvicorn without the missing Alembic CLI step

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dd031c1300832a82c0e3d7984848e1