### PR TITLE
Handle missing active project in chat endpoint

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,11 +1,17 @@
+from collections.abc import Mapping
+
 from fastapi import APIRouter, Form
+
 from backend.services.vector_memory import get_active_project
 from backend.services.intent_router import IntentRouter
 router = APIRouter()
 intent_router = IntentRouter()
 @router.post("/chat")
 async def chat(message: str = Form(...)):
-    active = get_active_project()
+    active = get_active_project() or {}
+    if not isinstance(active, Mapping):
+        active = {}
+
     project_id = active.get("id")
     collection = active.get("collection")
     intent_result = intent_router.route(message, project_id=project_id)

--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -1,1 +1,4 @@
-# Placeholder for backend/api/drive_diagnose.py
+from fastapi import APIRouter
+
+
+router = APIRouter()

--- a/backend/api/drive_scan.py
+++ b/backend/api/drive_scan.py
@@ -1,1 +1,4 @@
-# Placeholder for backend/api/drive_scan.py
+from fastapi import APIRouter
+
+
+router = APIRouter()

--- a/backend/api/speech.py
+++ b/backend/api/speech.py
@@ -1,1 +1,4 @@
-# Placeholder for backend/api/speech.py
+from fastapi import APIRouter
+
+
+router = APIRouter()

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -1,6 +1,56 @@
-_active_project_id = None
-def set_active_project(project_id: str):
-    global _active_project_id
-    _active_project_id = project_id
-def get_active_project():
-    return _active_project_id
+"""In-memory storage for the currently active project."""
+
+from __future__ import annotations
+
+from typing import Any, Mapping, MutableMapping, Optional
+
+
+_active_project: MutableMapping[str, Any] | None = None
+
+
+def _normalize_project(project: Any) -> MutableMapping[str, Any]:
+    """Normalize different project representations into a mutable mapping."""
+
+    if project is None:
+        return {}
+
+    if isinstance(project, Mapping):
+        return dict(project)
+
+    # Fallback to treating the project as an identifier only.
+    return {"id": project}
+
+
+def set_active_project(
+    project: Optional[Mapping[str, Any]] | Any = None,
+    *,
+    project_id: Optional[str] = None,
+    collection: Any = None,
+) -> None:
+    """Persist information about the active project.
+
+    The project can be supplied as a mapping containing arbitrary keys or as an
+    identifier. Optional keyword arguments can override the ``id`` and
+    ``collection`` entries to ensure callers receive a consistent structure.
+    """
+
+    global _active_project
+
+    normalized = _normalize_project(project)
+
+    if project_id is not None:
+        normalized["id"] = project_id
+
+    if collection is not None:
+        normalized["collection"] = collection
+
+    _active_project = normalized
+
+
+def get_active_project() -> MutableMapping[str, Any]:
+    """Return information about the active project as a mapping."""
+
+    if _active_project is None:
+        return {}
+
+    return _normalize_project(_active_project)

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,0 +1,27 @@
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.api.chat import router as chat_router
+from backend.services.vector_memory import set_active_project
+
+
+@pytest.fixture()
+def client():
+    app = FastAPI()
+    app.include_router(chat_router, prefix="/api")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_chat_without_active_project(client):
+    """Chat endpoint should handle missing active project gracefully."""
+
+    set_active_project(None)
+
+    response = client.post("/api/chat", data={"message": "Hello"})
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["project_id"] is None
+    assert payload["intent"]["project_id"] is None


### PR DESCRIPTION
## Summary
- normalize active project metadata in the vector memory service so callers always receive a mapping
- harden the chat API to handle missing project metadata without raising
- add a regression test for posting to /api/chat without an active project and provide minimal routers for placeholder modules used during app setup

## Testing
- pytest backend/tests/test_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68dd1971a63c832a8698f0f9f8a6339f