### PR TITLE
Handle empty chat documents gracefully

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -19,7 +19,17 @@ async def chat(message: str = Form(...)):
     if collection and hasattr(collection, "query"):
         try:
             res = collection.query(query_texts=[message], n_results=3)
-            context_docs = res.get("documents", [[]])[0]
+            documents = res.get("documents") if isinstance(res, Mapping) else None
+            if isinstance(documents, list) and documents:
+                first_entry = documents[0]
+                if isinstance(first_entry, list):
+                    context_docs = first_entry
+                elif first_entry is None:
+                    context_docs = []
+                else:
+                    context_docs = [first_entry]
+            else:
+                context_docs = []
         except Exception:
             context_docs = []
     return {"intent": intent_result, "project_id": project_id, "context_docs": context_docs, "response": f"AI response for project {project_id or 'none'}"}

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -25,3 +25,19 @@ def test_chat_without_active_project(client):
     payload = response.json()
     assert payload["project_id"] is None
     assert payload["intent"]["project_id"] is None
+
+
+def test_chat_with_empty_documents(client):
+    """Chat endpoint should handle empty document results gracefully."""
+
+    class EmptyDocumentsCollection:
+        def query(self, query_texts, n_results):  # pragma: no cover - simple stub
+            return {"documents": []}
+
+    set_active_project({"id": "proj-123", "collection": EmptyDocumentsCollection()})
+
+    response = client.post("/api/chat", data={"message": "Hello"})
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["context_docs"] == []


### PR DESCRIPTION
## Summary
- guard the chat endpoint against missing or empty document lists from vector queries
- cover the empty document scenario with a dedicated test

## Testing
- pytest backend/tests/test_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68dd20947ac4832a86699846dd1b313d