### PR TITLE
Add mock collection chat test coverage

### DIFF
--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -6,6 +6,17 @@ from backend.api.chat import router as chat_router
 from backend.services.vector_memory import set_active_project
 
 
+class _MockCollection:
+    """Predictable collection used to validate chat integration."""
+
+    def __init__(self):
+        self.queries = []
+
+    def query(self, query_texts, n_results):  # pragma: no cover - simple stub
+        self.queries.append({"query_texts": query_texts, "n_results": n_results})
+        return {"documents": [["Doc snippet"]]}
+
+
 @pytest.fixture()
 def client():
     app = FastAPI()
@@ -41,3 +52,23 @@ def test_chat_with_empty_documents(client):
 
     payload = response.json()
     assert payload["context_docs"] == []
+
+
+def test_chat_with_active_project_collection(client):
+    """Chat endpoint should return project context when collection is active."""
+
+    collection = _MockCollection()
+    set_active_project({"id": "proj-123", "collection": collection})
+
+    try:
+        response = client.post("/api/chat", data={"message": "Hello"})
+    finally:
+        set_active_project(None)
+
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["project_id"] == "proj-123"
+    assert payload["context_docs"] == ["Doc snippet"]
+    assert payload["response"].endswith("proj-123")
+    assert collection.queries == [{"query_texts": ["Hello"], "n_results": 3}]


### PR DESCRIPTION
## Summary
- add a reusable mock collection to exercise chat behavior with active projects
- verify chat responses include project context when a collection returns documents

## Testing
- pytest backend/tests/test_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2190bc78832a92198778690f73e7