### PR TITLE
Fix App.css block closures

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,6 +4,7 @@
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background-color: #0f172a;
   color: #e2e8f0;
+}
 
 body { margin: 0; }
 
@@ -48,5 +49,4 @@ body { margin: 0; }
 }
 @media (min-width: 768px) {
   .app__content { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
 }


### PR DESCRIPTION
## Summary
- close the :root declaration before the body styles so the body block stands alone
- remove the stray closing brace after the media query

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd2c7c7810832ab0a0e1cedb05a55a