### PR TITLE
Fix App.css root block closure

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -4,6 +4,7 @@
   font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
   background-color: #0f172a;
   color: #e2e8f0;
+}
 
 body { margin: 0; }
 
@@ -48,5 +49,4 @@ body { margin: 0; }
 }
 @media (min-width: 768px) {
   .app__content { grid-template-columns: repeat(2, minmax(0, 1fr)); }
-}
 }


### PR DESCRIPTION
## Summary
- close the :root block in App.css so subsequent selectors remain at the top level
- remove the stray closing brace to keep the stylesheet structure valid

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd2c6d67e8832abfda9b66776d5f63