### PR TITLE
Implement stubbed speech transcription endpoint

### DIFF
--- a/backend/api/speech.py
+++ b/backend/api/speech.py
@@ -1,10 +1,13 @@
-codex/update-active-project-storage-structure
 from __future__ import annotations
 
-from fastapi import APIRouter
+import io
+import logging
+from typing import Any, Callable, List, Optional
 
+from fastapi import APIRouter, File, UploadFile
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 @router.get("/speech/diagnostics")
@@ -13,14 +16,134 @@ def speech_diagnostics() -> dict[str, str]:
 
     return {"status": "stubbed", "detail": "Speech pipeline not available in tests"}
 
-"""Stub speech-to-text endpoint used for local development and tests."""
 
-from fastapi import APIRouter, File, UploadFile
+# Optional transcription backends -------------------------------------------------
+try:  # pragma: no cover - optional dependency path
+    from ..backend.services.speech_service import transcribe_audio as _advanced_transcribe
+except Exception:  # pragma: no cover - runtime optionality
+    _advanced_transcribe: Optional[Callable[..., Any]] = None
+else:  # pragma: no cover - imported when available
+    _advanced_transcribe = _advanced_transcribe
 
-router = APIRouter()
+try:  # pragma: no cover - optional dependency path
+    from ..services.speech_to_text import transcribe_audio as _service_transcribe
+except Exception:  # pragma: no cover - runtime optionality
+    _service_transcribe: Optional[Callable[..., Any]] = None
+else:  # pragma: no cover - imported when available
+    _service_transcribe = _service_transcribe
+
+try:  # pragma: no cover - optional dependency path
+    from .. import speech_to_text as _module_speech
+except Exception:  # pragma: no cover - runtime optionality
+    _module_transcribe: Optional[Callable[..., Any]] = None
+else:  # pragma: no cover - imported when available
+    _module_transcribe = getattr(_module_speech, "transcribe_audio", None)
+
+try:  # pragma: no cover - optional dependency path
+    from ..services.rag_memory import retrieve_with_memory as _retrieve_with_memory
+except Exception:  # pragma: no cover - runtime optionality
+    _retrieve_with_memory: Optional[Callable[[str], Any]] = None
+else:  # pragma: no cover - imported when available
+    _retrieve_with_memory = _retrieve_with_memory
+
+
+async def _read_upload(file: UploadFile) -> bytes:
+    contents = await file.read()
+    try:
+        file.file.seek(0)
+    except Exception:  # pragma: no cover - best effort reset
+        pass
+    return contents
+
+
+def _make_buffer(contents: bytes, filename: str | None) -> io.BytesIO:
+    buffer = io.BytesIO(contents)
+    buffer.name = filename or "audio.wav"
+    buffer.seek(0)
+    return buffer
+
+
+def _extract_transcript(result: Any) -> Optional[str]:
+    if isinstance(result, str):
+        cleaned = result.strip()
+        return cleaned if cleaned else None
+    if isinstance(result, dict):
+        for key in ("transcript", "text", "message"):
+            value = result.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return None
+
+
+async def _transcribe(file: UploadFile) -> str:
+    contents = await _read_upload(file)
+    if not contents:
+        return "No audio content received."
+
+    filename = file.filename or "uploaded-audio"
+    attempts: List[tuple[str, Callable[[], Any]]] = []
+
+    def add_attempt(name: str, func: Optional[Callable[..., Any]], *args: Any, **kwargs: Any) -> None:
+        if func is None:
+            return
+        attempts.append((name, lambda f=func, a=args, k=kwargs: f(*a, **k)))
+
+    add_attempt(
+        "backend.backend.services.speech_service",
+        _advanced_transcribe,
+        _make_buffer(contents, filename),
+    )
+    add_attempt(
+        "backend.services.speech_to_text",
+        _service_transcribe,
+        filename,
+    )
+    add_attempt(
+        "backend.speech_to_text",
+        _module_transcribe,
+        filename,
+    )
+
+    for name, call in attempts:
+        try:
+            result = call()
+            transcript = _extract_transcript(result)
+            if transcript:
+                return transcript
+        except Exception as exc:  # pragma: no cover - logging for troubleshooting
+            logger.debug("Speech transcription via %s failed: %s", name, exc, exc_info=True)
+
+    return "Transcription unavailable (stubbed)."
+
+
+def _generate_answer(project_id: str, transcript: str) -> str:
+    if _retrieve_with_memory is not None:
+        try:
+            rag_result = _retrieve_with_memory(transcript)
+            if isinstance(rag_result, dict):
+                answer = rag_result.get("answer")
+                if isinstance(answer, str) and answer.strip():
+                    return answer.strip()
+        except Exception as exc:  # pragma: no cover - optional path
+            logger.debug("RAG memory retrieval failed: %s", exc, exc_info=True)
+
+    transcript_preview = (transcript or "").strip()
+    if transcript_preview:
+        snippet = transcript_preview[:160]
+        if len(transcript_preview) > 160:
+            snippet = snippet.rstrip() + "…"
+        return (
+            "(stub) Unable to query project knowledge base for"
+            f" {project_id}. Transcript snippet: {snippet}"
+        )
+
+    return f"(stub) No transcript available to generate an answer for project {project_id}."
+
 
 @router.post("/speech/{project_id}")
 async def speech_to_text(project_id: str, file: UploadFile = File(...)) -> dict[str, str]:
-    """Echo the uploaded filename to confirm the speech route is wired up."""
-    return {"project_id": project_id, "filename": file.filename or ""}
- main
+    """Transcribe uploaded audio and provide a stubbed answer for the project."""
+
+    transcript = await _transcribe(file)
+    answer = _generate_answer(project_id, transcript)
+    return {"transcript": transcript, "answer": answer}


### PR DESCRIPTION
## Summary
- add FastAPI upload handling for /speech/{project_id}
- integrate with available speech transcription helpers and stub fallbacks
- return transcript and answer payload expected by the MicButton UI

## Testing
- python -m compileall backend/api/speech.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c842f24832a88c71c136ebae09f