### PR TITLE
Add router instance and smoke test for vision service

### DIFF
--- a/backend/services/intent_router.py
+++ b/backend/services/intent_router.py
@@ -1,8 +1,39 @@
+from __future__ import annotations
+
+import re
+from collections.abc import Callable, Iterable
+
+
 class IntentRouter:
-    def route(self, message: str, project_id: str = None):
+    def __init__(self) -> None:
+        self._services: list[tuple[str, list[re.Pattern[str]], Callable[..., object]]] = []
+
+    def register(
+        self, name: str, patterns: Iterable[str] | str, handler: Callable[..., object]
+    ) -> None:
+        normalized_patterns = [patterns] if isinstance(patterns, str) else list(patterns)
+        compiled_patterns = [re.compile(pattern, re.IGNORECASE) for pattern in normalized_patterns]
+        self._services.append((name, compiled_patterns, handler))
+
+    def route(self, message: str, project_id: str | None = None):
+        text = message if isinstance(message, str) else "" if message is None else str(message)
+
+        for name, patterns, _ in self._services:
+            if any(pattern.search(text) for pattern in patterns):
+                return {"intent": name, "message": message, "project_id": project_id}
+
         intent = "unknown"
-        m = message.lower()
-        if "upload" in m: intent = "UPLOAD_DOC"
-        elif "image" in m or "photo" in m: intent = "VISION_ANALYZE"
-        elif "audio" in m or "mic" in m: intent = "TRANSCRIBE_AUDIO"
+        lower_text = text.lower()
+        if "upload" in lower_text:
+            intent = "UPLOAD_DOC"
+        elif "image" in lower_text or "photo" in lower_text:
+            intent = "VISION_ANALYZE"
+        elif "audio" in lower_text or "mic" in lower_text:
+            intent = "TRANSCRIBE_AUDIO"
+
         return {"intent": intent, "message": message, "project_id": project_id}
+
+
+router = IntentRouter()
+
+__all__ = ["IntentRouter", "router"]

--- a/backend/tests/test_services_smoke.py
+++ b/backend/tests/test_services_smoke.py
@@ -1,0 +1,6 @@
+import importlib
+
+
+def test_import_vision_module() -> None:
+    module = importlib.import_module("backend.services.vision")
+    assert hasattr(module, "handle_vision")


### PR DESCRIPTION
## Summary
- update the intent router to expose a shared module-level instance and support handler registration
- ensure the vision service registers against the shared router and provide a smoke test that imports the module

## Testing
- pytest backend/tests/test_services_smoke.py *(fails: ImportError caused by pre-existing indentation error in backend/api/chat.py)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2c6df5e0832a98faa5374584e3b7