### PR TITLE
Restore drive health test and repair API stubs

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -2,25 +2,24 @@ from collections.abc import Mapping
 
 from fastapi import APIRouter, Form
 
-from backend.services.vector_memory import get_active_project
 from backend.services.intent_router import IntentRouter
+from backend.services.vector_memory import get_active_project
+
 router = APIRouter()
 intent_router = IntentRouter()
+
+
 @router.post("/chat")
 async def chat(message: str = Form(...)):
     active = get_active_project() or {}
- codex/update-active-project-storage-structure
-
-    project_id = active.get("id") if isinstance(active, dict) else getattr(active, "id", None)
-    collection = active.get("collection") if isinstance(active, dict) else getattr(active, "collection", None)
-
     if not isinstance(active, Mapping):
         active = {}
 
     project_id = active.get("id")
     collection = active.get("collection")
- main
+
     intent_result = intent_router.route(message, project_id=project_id)
+
     context_docs = []
     if collection and hasattr(collection, "query"):
         try:
@@ -38,9 +37,11 @@ async def chat(message: str = Form(...)):
                 context_docs = []
         except Exception:
             context_docs = []
+
     return {
         "intent": intent_result,
         "project_id": project_id,
         "context_docs": context_docs,
         "response": f"AI response for project {project_id or 'none'}",
     }
+

--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -1,8 +1,6 @@
- codex/update-active-project-storage-structure
 from __future__ import annotations
 
 from fastapi import APIRouter
-
 
 router = APIRouter()
 
@@ -13,8 +11,3 @@ def drive_diagnostics() -> dict[str, str]:
 
     return {"status": "ok", "detail": "Drive diagnostics not implemented in tests"}
 
-from fastapi import APIRouter
-
-
-router = APIRouter()
- main

--- a/backend/api/drive_scan.py
+++ b/backend/api/drive_scan.py
@@ -1,8 +1,6 @@
-codex/update-active-project-storage-structure
 from __future__ import annotations
 
 from fastapi import APIRouter
-
 
 router = APIRouter()
 
@@ -13,8 +11,3 @@ def drive_scan_status() -> dict[str, str]:
 
     return {"status": "idle", "detail": "Drive scanning is not available in tests"}
 
-from fastapi import APIRouter
-
-
-router = APIRouter()
- main

--- a/backend/api/speech.py
+++ b/backend/api/speech.py
@@ -1,8 +1,8 @@
-codex/update-active-project-storage-structure
+"""Stub speech-to-text endpoints used for local development and tests."""
+
 from __future__ import annotations
 
-from fastapi import APIRouter
-
+from fastapi import APIRouter, File, UploadFile
 
 router = APIRouter()
 
@@ -13,14 +13,10 @@ def speech_diagnostics() -> dict[str, str]:
 
     return {"status": "stubbed", "detail": "Speech pipeline not available in tests"}
 
-"""Stub speech-to-text endpoint used for local development and tests."""
-
-from fastapi import APIRouter, File, UploadFile
-
-router = APIRouter()
 
 @router.post("/speech/{project_id}")
 async def speech_to_text(project_id: str, file: UploadFile = File(...)) -> dict[str, str]:
     """Echo the uploaded filename to confirm the speech route is wired up."""
+
     return {"project_id": project_id, "filename": file.filename or ""}
- main
+

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -1,138 +1,8 @@
- codex/update-active-project-storage-structure
-from typing import Any, Dict, Optional
-
-
-_active_project: Optional[Dict[str, Any]] = None
-
-
-def set_active_project(project: Optional[Dict[str, Any]]):
-    """Persist the currently active project.
-
-    The active project is stored as a dictionary so that both the project
-    identifier and any associated collection-like object can be retrieved by
-    other services. Passing ``None`` clears the active project.
-
-"""In-memory storage for the currently active project."""
-
-from __future__ import annotations
-
-from typing import Any, Mapping, MutableMapping, Optional
-
-_active_project: MutableMapping[str, Any] | None = None
-
-
-def _normalize_project(project: Any) -> MutableMapping[str, Any]:
-    """Normalize different project representations into a mutable mapping."""
-
-    if project is None:
-        return {}
-
-    if isinstance(project, Mapping):
-        return dict(project)
-
-    # Fallback to treating the project as an identifier only.
-    return {"id": project}
-
-
-def set_active_project(
-    project: Optional[Mapping[str, Any]] | Any = None,
-    *,
-    project_id: Optional[str] = None,
-    collection: Any = None,
-) -> None:
-    """Persist information about the active project.
-
-    The project can be supplied as a mapping containing arbitrary keys or as an
-    identifier. Optional keyword arguments can override the ``id`` and
-    ``collection`` entries to ensure callers receive a consistent structure.
- main
-    """
-
-    global _active_project
-
-codex/update-active-project-storage-structure
-    if project is None:
-        _active_project = None
-        return
-
-    if isinstance(project, str):
-        _active_project = {"id": project, "collection": None}
-        return
-
-    if not isinstance(project, dict):
-        raise TypeError("project must be a mapping with 'id' and 'collection' keys")
-
-    _active_project = {
-        "id": project.get("id"),
-        "collection": project.get("collection"),
-    }
-
-
-def get_active_project() -> Optional[Dict[str, Any]]:
-    """Return the currently active project structure, if any."""
-
-    return _active_project
-
-    normalized = _normalize_project(project)
-
-    if project_id is not None:
-        normalized["id"] = project_id
-
-    if collection is not None:
-        normalized["collection"] = collection
-
-    _active_project = normalized
-
-
-def get_active_project() -> MutableMapping[str, Any]:
-    """Return information about the active project as a mapping."""
-
-    if _active_project is None:
-        return {}
-
-    return _normalize_project(_active_project)
 """Utilities for tracking the project currently targeted by chat sessions."""
 
 from __future__ import annotations
 
-from typing import Any, Mapping
-
-_DEFAULT_PROJECT_PAYLOAD = {"id": None, "collection": None}
-_active_project_payload = dict(_DEFAULT_PROJECT_PAYLOAD)
-
-
-def set_active_project(project: Mapping[str, Any] | None = None) -> None:
-    """Set the in-memory active project payload.
-
-    Parameters
-    ----------
-    project:
-        A mapping describing the project context. The mapping should include an
-        ``id`` entry as well as an optional ``collection`` used for semantic
-        search. When ``None`` is provided the active project is cleared and the
-        default payload with ``None`` values is restored.
-    """
-
-    global _active_project_payload
-
-    payload = dict(_DEFAULT_PROJECT_PAYLOAD)
-    if project:
-        payload["id"] = project.get("id")
-        payload["collection"] = project.get("collection")
-
-    _active_project_payload = payload
-
-
-def get_active_project() -> dict[str, Any]:
-    """Return a shallow copy of the active project payload."""
-
-    return dict(_active_project_payload)
-"""In-memory storage for the currently active project."""
-
-from __future__ import annotations
-
 from typing import Any, Mapping, MutableMapping, Optional
-
 
 _active_project: MutableMapping[str, Any] | None = None
 
@@ -146,7 +16,6 @@ def _normalize_project(project: Any) -> MutableMapping[str, Any]:
     if isinstance(project, Mapping):
         return dict(project)
 
-    # Fallback to treating the project as an identifier only.
     return {"id": project}
 
 
@@ -156,14 +25,13 @@ def set_active_project(
     project_id: Optional[str] = None,
     collection: Any = None,
 ) -> None:
-    """Persist information about the active project.
-
-    The project can be supplied as a mapping containing arbitrary keys or as an
-    identifier. Optional keyword arguments can override the ``id`` and
-    ``collection`` entries to ensure callers receive a consistent structure.
-    """
+    """Persist information about the active project."""
 
     global _active_project
+
+    if project is None and project_id is None and collection is None:
+        _active_project = None
+        return
 
     normalized = _normalize_project(project)
 
@@ -172,6 +40,8 @@ def set_active_project(
 
     if collection is not None:
         normalized["collection"] = collection
+    elif "collection" not in normalized:
+        normalized["collection"] = None
 
     _active_project = normalized
 
@@ -183,4 +53,4 @@ def get_active_project() -> MutableMapping[str, Any]:
         return {}
 
     return _normalize_project(_active_project)
- main
+

--- a/backend/tests/test_drive_health_errors.py
+++ b/backend/tests/test_drive_health_errors.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from pytest import MonkeyPatch
+
+from backend.services import google_drive
+
+
+def test_upload_attempts_to_initialise_drive_service(monkeypatch: MonkeyPatch) -> None:
+    attempts: list[str] = []
+
+    def fake_get_drive_service() -> None:
+        attempts.append("called")
+        raise RuntimeError("service unavailable")
+
+    monkeypatch.setattr(google_drive, "get_drive_service", fake_get_drive_service)
+
+    result = google_drive.upload_to_drive(object())
+
+    assert result == "stubbed-upload-id"
+    assert attempts, "expected upload_to_drive to attempt to initialise the Drive service"
+


### PR DESCRIPTION
## Summary
- restore the drive health regression test to ensure upload attempts initialise the Drive service
- clean up corrupted API stub modules for chat, drive diagnostics, drive scan, and speech endpoints
- rebuild the vector memory helper to provide consistent active-project handling for the chat API

## Testing
- pytest backend/tests/test_drive_health_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c7bb3dc832aae6ecad2c53f6e8d