### PR TITLE
Refine chat active project handling and tests

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -1,43 +1,46 @@
+"""Chat endpoint exposing the assistant interface."""
+
 from collections.abc import Mapping
 
 from fastapi import APIRouter, Form
 
-from backend.services.vector_memory import get_active_project
 from backend.services.intent_router import IntentRouter
+from backend.services.vector_memory import get_active_project
+
 router = APIRouter()
 intent_router = IntentRouter()
+
+
 @router.post("/chat")
 async def chat(message: str = Form(...)):
+    """Respond to chat messages while respecting the active project context."""
+
     active = get_active_project() or {}
- codex/update-active-project-storage-structure
-
-    project_id = active.get("id") if isinstance(active, dict) else getattr(active, "id", None)
-    collection = active.get("collection") if isinstance(active, dict) else getattr(active, "collection", None)
-
     if not isinstance(active, Mapping):
         active = {}
 
     project_id = active.get("id")
     collection = active.get("collection")
- main
+
     intent_result = intent_router.route(message, project_id=project_id)
-    context_docs = []
+
+    context_docs: list[str] = []
     if collection and hasattr(collection, "query"):
         try:
-            res = collection.query(query_texts=[message], n_results=3)
-            documents = res.get("documents") if isinstance(res, Mapping) else None
-            if isinstance(documents, list) and documents:
-                first_entry = documents[0]
-                if isinstance(first_entry, list):
-                    context_docs = first_entry
-                elif first_entry is None:
-                    context_docs = []
-                else:
-                    context_docs = [first_entry]
-            else:
-                context_docs = []
-        except Exception:
+            result = collection.query(query_texts=[message], n_results=3)
+            if isinstance(result, Mapping):
+                documents = result.get("documents")
+                if isinstance(documents, list) and documents:
+                    first_entry = documents[0]
+                    if isinstance(first_entry, list):
+                        context_docs = first_entry
+                    elif first_entry is None:
+                        context_docs = []
+                    else:
+                        context_docs = [first_entry]
+        except Exception:  # pragma: no cover - defensive guard
             context_docs = []
+
     return {
         "intent": intent_result,
         "project_id": project_id,

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -1,17 +1,3 @@
- codex/update-active-project-storage-structure
-from typing import Any, Dict, Optional
-
-
-_active_project: Optional[Dict[str, Any]] = None
-
-
-def set_active_project(project: Optional[Dict[str, Any]]):
-    """Persist the currently active project.
-
-    The active project is stored as a dictionary so that both the project
-    identifier and any associated collection-like object can be retrieved by
-    other services. Passing ``None`` clears the active project.
-
 """In-memory storage for the currently active project."""
 
 from __future__ import annotations
@@ -30,7 +16,6 @@ def _normalize_project(project: Any) -> MutableMapping[str, Any]:
     if isinstance(project, Mapping):
         return dict(project)
 
-    # Fallback to treating the project as an identifier only.
     return {"id": project}
 
 
@@ -40,38 +25,9 @@ def set_active_project(
     project_id: Optional[str] = None,
     collection: Any = None,
 ) -> None:
-    """Persist information about the active project.
-
-    The project can be supplied as a mapping containing arbitrary keys or as an
-    identifier. Optional keyword arguments can override the ``id`` and
-    ``collection`` entries to ensure callers receive a consistent structure.
- main
-    """
+    """Persist information about the active project."""
 
     global _active_project
-
-codex/update-active-project-storage-structure
-    if project is None:
-        _active_project = None
-        return
-
-    if isinstance(project, str):
-        _active_project = {"id": project, "collection": None}
-        return
-
-    if not isinstance(project, dict):
-        raise TypeError("project must be a mapping with 'id' and 'collection' keys")
-
-    _active_project = {
-        "id": project.get("id"),
-        "collection": project.get("collection"),
-    }
-
-
-def get_active_project() -> Optional[Dict[str, Any]]:
-    """Return the currently active project structure, if any."""
-
-    return _active_project
 
     normalized = _normalize_project(project)
 
@@ -80,6 +36,8 @@ def get_active_project() -> Optional[Dict[str, Any]]:
 
     if collection is not None:
         normalized["collection"] = collection
+    elif "collection" not in normalized:
+        normalized["collection"] = None
 
     _active_project = normalized
 
@@ -91,96 +49,3 @@ def get_active_project() -> MutableMapping[str, Any]:
         return {}
 
     return _normalize_project(_active_project)
-"""Utilities for tracking the project currently targeted by chat sessions."""
-
-from __future__ import annotations
-
-from typing import Any, Mapping
-
-_DEFAULT_PROJECT_PAYLOAD = {"id": None, "collection": None}
-_active_project_payload = dict(_DEFAULT_PROJECT_PAYLOAD)
-
-
-def set_active_project(project: Mapping[str, Any] | None = None) -> None:
-    """Set the in-memory active project payload.
-
-    Parameters
-    ----------
-    project:
-        A mapping describing the project context. The mapping should include an
-        ``id`` entry as well as an optional ``collection`` used for semantic
-        search. When ``None`` is provided the active project is cleared and the
-        default payload with ``None`` values is restored.
-    """
-
-    global _active_project_payload
-
-    payload = dict(_DEFAULT_PROJECT_PAYLOAD)
-    if project:
-        payload["id"] = project.get("id")
-        payload["collection"] = project.get("collection")
-
-    _active_project_payload = payload
-
-
-def get_active_project() -> dict[str, Any]:
-    """Return a shallow copy of the active project payload."""
-
-    return dict(_active_project_payload)
-"""In-memory storage for the currently active project."""
-
-from __future__ import annotations
-
-from typing import Any, Mapping, MutableMapping, Optional
-
-
-_active_project: MutableMapping[str, Any] | None = None
-
-
-def _normalize_project(project: Any) -> MutableMapping[str, Any]:
-    """Normalize different project representations into a mutable mapping."""
-
-    if project is None:
-        return {}
-
-    if isinstance(project, Mapping):
-        return dict(project)
-
-    # Fallback to treating the project as an identifier only.
-    return {"id": project}
-
-
-def set_active_project(
-    project: Optional[Mapping[str, Any]] | Any = None,
-    *,
-    project_id: Optional[str] = None,
-    collection: Any = None,
-) -> None:
-    """Persist information about the active project.
-
-    The project can be supplied as a mapping containing arbitrary keys or as an
-    identifier. Optional keyword arguments can override the ``id`` and
-    ``collection`` entries to ensure callers receive a consistent structure.
-    """
-
-    global _active_project
-
-    normalized = _normalize_project(project)
-
-    if project_id is not None:
-        normalized["id"] = project_id
-
-    if collection is not None:
-        normalized["collection"] = collection
-
-    _active_project = normalized
-
-
-def get_active_project() -> MutableMapping[str, Any]:
-    """Return information about the active project as a mapping."""
-
-    if _active_project is None:
-        return {}
-
-    return _normalize_project(_active_project)
- main

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -1,16 +1,12 @@
-codex/update-active-project-storage-structure
-
 """Tests for the chat endpoint to ensure active project handling."""
 
- main
 from collections.abc import Generator
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-codex/update-active-project-storage-structure
-from backend.api import chat
+from backend.api.chat import router as chat_router
 from backend.services.vector_memory import set_active_project
 
 
@@ -19,153 +15,61 @@ def client() -> Generator[TestClient, None, None]:
     """Provide a lightweight FastAPI test client with only the chat router."""
 
     app = FastAPI()
-    app.include_router(chat.router, prefix="/api")
+    app.include_router(chat_router, prefix="/api")
 
-
-from backend.api.chat import router as chat_router
-from backend.services.vector_memory import set_active_project
+    with TestClient(app) as test_client:
+        yield test_client
 
 
 class _MockCollection:
     """Predictable collection used to validate chat integration."""
 
- codex/add-tests-for-active-project-in-chat
     def __init__(self) -> None:
-        self.calls = []
-
-    def query(self, *, query_texts, n_results):  # pragma: no cover - simple stub
-        self.calls.append({"query_texts": query_texts, "n_results": n_results})
-
-    def __init__(self):
-codex/add-tests-for-active-project-in-chat-y0qgyr
         self.queries: list[dict[str, object]] = []
 
     def query(self, *, query_texts, n_results):  # pragma: no cover - simple stub
         """Record the provided arguments and emit deterministic documents."""
 
-
-        self.queries = []
- codex/update-vector_memory-to-handle-project-payload
-    def query(self, *, query_texts, n_results):  # pragma: no cover - simple stub
-
- codex/add-tests-for-active-project-in-chat-ojreow
-    def query(self, *, query_texts, n_results):  # pragma: no cover - simple stub
-
-codex/add-tests-for-active-project-in-chat-nr6q6k
-    def query(self, *, query_texts, n_results):  # pragma: no cover - simple stub
-
-    def query(self, query_texts, n_results):  # pragma: no cover - simple stub
- main
- main
- main
- main
         self.queries.append({"query_texts": query_texts, "n_results": n_results})
-main
         return {"documents": [["Doc snippet"]]}
 
 
-@pytest.fixture()
-def client():
-    app = FastAPI()
-    app.include_router(chat_router, prefix="/api") 
-       main
-    with TestClient(app) as test_client:
-        yield test_client
-
-
-def test_chat_without_active_project(client):
- codex/update-active-project-storage-structure
+def test_chat_without_active_project(client: TestClient) -> None:
     """Chat endpoint should respond gracefully when no project is selected."""
 
     set_active_project(None)
 
-    response = client.post("/api/chat", data={"message": "hello"})
-
-    """Chat endpoint should handle missing active project gracefully."""
-
-    set_active_project(None)
     response = client.post("/api/chat", data={"message": "Hello"})
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["project_id"] is None
- codex/update-vector_memory-to-handle-project-payload
-    if "intent" in payload:
-        assert payload["intent"]["project_id"] is None
-
-    assert payload.get("context_docs", []) == []
-    assert payload["intent"]["project_id"] is None
-
- main
-
-
-codex/update-vector_memory-to-handle-project-payload
-def test_chat_with_active_project_collection(client):
-    """When an active project includes a collection, results are surfaced."""
-
-    set_active_project({"id": "proj-123", "collection": _MockCollection()})
-
-    class EmptyDocumentsCollection:
-        def query(self, *, query_texts, n_results):  # pragma: no cover - simple stub
-            return {"documents": []}
-
-    set_active_project({"id": "proj-123", "collection": EmptyDocumentsCollection()})
-    try:
-        response = client.post("/api/chat", data={"message": "Hello"})
-    finally:
-        set_active_project(None)
-
-codex/add-tests-for-active-project-in-chat
-    try:
-        response = client.post("/api/chat", data={"message": "Hello"})
-    finally:
-        set_active_project(None)
- main
- main
 
     assert response.status_code == 200
 
     payload = response.json()
- codex/update-active-project-storage-structure
     assert payload["project_id"] is None
     assert payload["context_docs"] == []
-    assert payload["intent"]["intent"] == "unknown"
-
-    assert payload.get("context_docs", []) == []
+    assert payload["intent"]["project_id"] is None
 
 
-def test_chat_with_active_project_collection(client):
-    """Chat endpoint should return project context when collection is active."""
+def test_chat_with_active_project_collection(client: TestClient) -> None:
+    """When an active project includes a collection, results are surfaced."""
 
     collection = _MockCollection()
     set_active_project({"id": "proj-123", "collection": collection})
 
- codex/add-tests-for-active-project-in-chat-ojreow
- main
-
     try:
         response = client.post("/api/chat", data={"message": "Hello"})
     finally:
         set_active_project(None)
 
- codex/add-tests-for-active-project-in-chat
     assert response.status_code == 200
 
     payload = response.json()
     assert payload["project_id"] == "proj-123"
     assert payload["context_docs"] == ["Doc snippet"]
     assert "proj-123" in payload["response"]
-    assert collection.calls == [{"query_texts": ["Hello"], "n_results": 3}]
-
- main
-    assert response.status_code == 200
-    payload = response.json()
-    assert payload["project_id"] == "proj-123"
-    if "context_docs" in payload:
-        assert payload["context_docs"] == ["Doc snippet"]
-    assert "proj-123" in payload["response"]
+    assert collection.queries == [{"query_texts": ["Hello"], "n_results": 3}]
 
 
-def test_chat_with_empty_documents(client):
+def test_chat_with_empty_documents(client: TestClient) -> None:
     """Chat endpoint should handle empty document results gracefully."""
 
     class EmptyDocumentsCollection:
@@ -174,20 +78,13 @@ def test_chat_with_empty_documents(client):
 
     set_active_project({"id": "proj-123", "collection": EmptyDocumentsCollection()})
 
-    response = client.post("/api/chat", data={"message": "Hello"})
+    try:
+        response = client.post("/api/chat", data={"message": "Hello"})
+    finally:
+        set_active_project(None)
+
     assert response.status_code == 200
 
     payload = response.json()
- codex/update-vector_memory-to-handle-project-payload
-    assert payload["context_docs"] == []
-
     assert payload["project_id"] == "proj-123"
-    assert payload["context_docs"] == ["Doc snippet"]
- codex/add-tests-for-active-project-in-chat-y0qgyr
-    assert "proj-123" in payload["response"]
-
-    assert payload["response"].endswith("proj-123") main
-    assert collection.queries == [{"query_texts": ["Hello"], "n_results": 3}]
- main
-main
-      main
+    assert payload["context_docs"] == []


### PR DESCRIPTION
## Summary
- clean up the chat API to normalize project metadata and surface context documents safely
- simplify vector memory storage to provide normalized active project mappings
- add a deterministic mock collection and active-project chat test coverage

## Testing
- pytest backend/tests/test_chat.py *(fails: ImportError from backend/api/drive_diagnose.py due to pre-existing indentation error)*

------
https://chatgpt.com/codex/tasks/task_e_68dd2fdf99cc832aa1811457f1ff1ac5