### PR TITLE
Add drive upload fallback test and restore API modules

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -2,24 +2,22 @@ from collections.abc import Mapping
 
 from fastapi import APIRouter, Form
 
-from backend.services.vector_memory import get_active_project
 from backend.services.intent_router import IntentRouter
+from backend.services.vector_memory import get_active_project
+
 router = APIRouter()
 intent_router = IntentRouter()
+
+
 @router.post("/chat")
 async def chat(message: str = Form(...)):
     active = get_active_project() or {}
- codex/update-active-project-storage-structure
-
-    project_id = active.get("id") if isinstance(active, dict) else getattr(active, "id", None)
-    collection = active.get("collection") if isinstance(active, dict) else getattr(active, "collection", None)
-
     if not isinstance(active, Mapping):
         active = {}
 
     project_id = active.get("id")
     collection = active.get("collection")
- main
+
     intent_result = intent_router.route(message, project_id=project_id)
     context_docs = []
     if collection and hasattr(collection, "query"):

--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -1,8 +1,4 @@
- codex/update-active-project-storage-structure
-from __future__ import annotations
-
 from fastapi import APIRouter
-
 
 router = APIRouter()
 
@@ -12,9 +8,3 @@ def drive_diagnostics() -> dict[str, str]:
     """Return a stubbed response representing drive diagnostics."""
 
     return {"status": "ok", "detail": "Drive diagnostics not implemented in tests"}
-
-from fastapi import APIRouter
-
-
-router = APIRouter()
- main

--- a/backend/api/drive_scan.py
+++ b/backend/api/drive_scan.py
@@ -1,8 +1,4 @@
-codex/update-active-project-storage-structure
-from __future__ import annotations
-
 from fastapi import APIRouter
-
 
 router = APIRouter()
 
@@ -12,9 +8,3 @@ def drive_scan_status() -> dict[str, str]:
     """Return a stubbed response representing drive scanning state."""
 
     return {"status": "idle", "detail": "Drive scanning is not available in tests"}
-
-from fastapi import APIRouter
-
-
-router = APIRouter()
- main

--- a/backend/api/speech.py
+++ b/backend/api/speech.py
@@ -1,8 +1,4 @@
-codex/update-active-project-storage-structure
-from __future__ import annotations
-
-from fastapi import APIRouter
-
+from fastapi import APIRouter, File, UploadFile
 
 router = APIRouter()
 
@@ -13,14 +9,9 @@ def speech_diagnostics() -> dict[str, str]:
 
     return {"status": "stubbed", "detail": "Speech pipeline not available in tests"}
 
-"""Stub speech-to-text endpoint used for local development and tests."""
-
-from fastapi import APIRouter, File, UploadFile
-
-router = APIRouter()
 
 @router.post("/speech/{project_id}")
 async def speech_to_text(project_id: str, file: UploadFile = File(...)) -> dict[str, str]:
     """Echo the uploaded filename to confirm the speech route is wired up."""
+
     return {"project_id": project_id, "filename": file.filename or ""}
- main

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -1,17 +1,3 @@
- codex/update-active-project-storage-structure
-from typing import Any, Dict, Optional
-
-
-_active_project: Optional[Dict[str, Any]] = None
-
-
-def set_active_project(project: Optional[Dict[str, Any]]):
-    """Persist the currently active project.
-
-    The active project is stored as a dictionary so that both the project
-    identifier and any associated collection-like object can be retrieved by
-    other services. Passing ``None`` clears the active project.
-
 """In-memory storage for the currently active project."""
 
 from __future__ import annotations
@@ -40,128 +26,7 @@ def set_active_project(
     project_id: Optional[str] = None,
     collection: Any = None,
 ) -> None:
-    """Persist information about the active project.
-
-    The project can be supplied as a mapping containing arbitrary keys or as an
-    identifier. Optional keyword arguments can override the ``id`` and
-    ``collection`` entries to ensure callers receive a consistent structure.
- main
-    """
-
-    global _active_project
-
-codex/update-active-project-storage-structure
-    if project is None:
-        _active_project = None
-        return
-
-    if isinstance(project, str):
-        _active_project = {"id": project, "collection": None}
-        return
-
-    if not isinstance(project, dict):
-        raise TypeError("project must be a mapping with 'id' and 'collection' keys")
-
-    _active_project = {
-        "id": project.get("id"),
-        "collection": project.get("collection"),
-    }
-
-
-def get_active_project() -> Optional[Dict[str, Any]]:
-    """Return the currently active project structure, if any."""
-
-    return _active_project
-
-    normalized = _normalize_project(project)
-
-    if project_id is not None:
-        normalized["id"] = project_id
-
-    if collection is not None:
-        normalized["collection"] = collection
-
-    _active_project = normalized
-
-
-def get_active_project() -> MutableMapping[str, Any]:
-    """Return information about the active project as a mapping."""
-
-    if _active_project is None:
-        return {}
-
-    return _normalize_project(_active_project)
-"""Utilities for tracking the project currently targeted by chat sessions."""
-
-from __future__ import annotations
-
-from typing import Any, Mapping
-
-_DEFAULT_PROJECT_PAYLOAD = {"id": None, "collection": None}
-_active_project_payload = dict(_DEFAULT_PROJECT_PAYLOAD)
-
-
-def set_active_project(project: Mapping[str, Any] | None = None) -> None:
-    """Set the in-memory active project payload.
-
-    Parameters
-    ----------
-    project:
-        A mapping describing the project context. The mapping should include an
-        ``id`` entry as well as an optional ``collection`` used for semantic
-        search. When ``None`` is provided the active project is cleared and the
-        default payload with ``None`` values is restored.
-    """
-
-    global _active_project_payload
-
-    payload = dict(_DEFAULT_PROJECT_PAYLOAD)
-    if project:
-        payload["id"] = project.get("id")
-        payload["collection"] = project.get("collection")
-
-    _active_project_payload = payload
-
-
-def get_active_project() -> dict[str, Any]:
-    """Return a shallow copy of the active project payload."""
-
-    return dict(_active_project_payload)
-"""In-memory storage for the currently active project."""
-
-from __future__ import annotations
-
-from typing import Any, Mapping, MutableMapping, Optional
-
-
-_active_project: MutableMapping[str, Any] | None = None
-
-
-def _normalize_project(project: Any) -> MutableMapping[str, Any]:
-    """Normalize different project representations into a mutable mapping."""
-
-    if project is None:
-        return {}
-
-    if isinstance(project, Mapping):
-        return dict(project)
-
-    # Fallback to treating the project as an identifier only.
-    return {"id": project}
-
-
-def set_active_project(
-    project: Optional[Mapping[str, Any]] | Any = None,
-    *,
-    project_id: Optional[str] = None,
-    collection: Any = None,
-) -> None:
-    """Persist information about the active project.
-
-    The project can be supplied as a mapping containing arbitrary keys or as an
-    identifier. Optional keyword arguments can override the ``id`` and
-    ``collection`` entries to ensure callers receive a consistent structure.
-    """
+    """Persist information about the active project."""
 
     global _active_project
 
@@ -183,4 +48,3 @@ def get_active_project() -> MutableMapping[str, Any]:
         return {}
 
     return _normalize_project(_active_project)
- main

--- a/backend/tests/test_drive_health_errors.py
+++ b/backend/tests/test_drive_health_errors.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib
+from types import ModuleType, SimpleNamespace
+
+import pytest
+
+import backend.services.google_drive as google_drive
+
+
+@pytest.fixture
+def drive_module() -> ModuleType:
+    module = importlib.reload(google_drive)
+    try:
+        yield module
+    finally:
+        importlib.reload(google_drive)
+
+
+def test_upload_attempts_to_initialise_drive_service(drive_module: ModuleType, monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[str] = []
+
+    def fake_get_drive_service() -> None:
+        calls.append("get_drive_service")
+        raise RuntimeError("expected failure")
+
+    monkeypatch.setattr(drive_module, "get_drive_service", fake_get_drive_service)
+
+    class DummyHandle:
+        def __init__(self) -> None:
+            self.read_calls = 0
+            self.seek_calls = 0
+
+        def read(self) -> bytes:
+            self.read_calls += 1
+            return b"payload"
+
+        def seek(self, position: int) -> None:
+            self.seek_calls += 1
+            if position != 0:
+                raise AssertionError("unexpected seek position")
+
+    dummy_file = SimpleNamespace(
+        file=DummyHandle(),
+        filename="dummy.txt",
+        content_type="text/plain",
+    )
+
+    result = drive_module.upload_to_drive(dummy_file)
+
+    assert result == "stubbed-upload-id"
+    assert calls == ["get_drive_service"]
+    assert dummy_file.file.read_calls == 0
+    assert dummy_file.file.seek_calls == 0


### PR DESCRIPTION
## Summary
- clean up several API modules and the vector memory helper to resolve merge artefacts
- add a regression test ensuring `upload_to_drive` falls back to the stub identifier when service initialisation fails

## Testing
- pytest backend/tests/test_drive_health_errors.py

------
https://chatgpt.com/codex/tasks/task_e_68dd2c675368832abed67c8c3bb6d77b