### PR TITLE
Fix Render YAML service definitions

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -17,15 +17,13 @@ services:
         fromService:
           name: mba-redis
           property: connectionString
+  - type: redis
+    name: mba-redis
+    plan: starter
+    region: oregon
 
 databases:
   - name: mba-postgres-main
     databaseName: masterise_ai_main
-    plan: starter
-    region: oregon
-
-services:
-  - type: redis
-    name: mba-redis
     plan: starter
     region: oregon


### PR DESCRIPTION
## Summary
- consolidate the web and redis configuration blocks into a single Render services list
- keep the database configuration intact while ensuring the YAML structure is valid for deployment

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dd37d9ad38832abec457aa1ead0923