### PR TITLE
Enhance Drive stub diagnostics for missing credentials

### DIFF
--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -13,10 +13,13 @@ def drive_diagnose() -> Dict[str, Any]:
     """Return debugging details about the Google Drive connection."""
     service = google_drive.get_drive_service()
     if service is None:
+        diagnostics = google_drive.drive_stub_diagnostics()
         return {
             "status": "stubbed",
-            "detail": google_drive.drive_service_error(),
-            "credentials_available": google_drive.drive_credentials_available(),
+            "detail": diagnostics["service_error"],
+            "credentials_available": diagnostics["credentials_available"],
+            "credentials_hint": diagnostics["credentials_hint"],
+            "stubbed": diagnostics["stubbed"],
             "projects": google_drive.list_project_folders(lookup_service=False),
         }
 

--- a/backend/tests/test_drive_stubbed_endpoints.py
+++ b/backend/tests/test_drive_stubbed_endpoints.py
@@ -32,6 +32,10 @@ def test_health_reports_missing_credentials(stubbed_client: TestClient) -> None:
     # service_error should be recorded even before any Drive call
     assert "Credentials" in payload["drive"]["service_error"]
     assert payload["drive"]["stubbed"] is True
+    hint = payload["drive"]["credentials_hint"]
+    assert hint["env_var_set"] is True
+    assert hint["expected_path"] == str(Path("/tmp/google-credentials-missing.json"))
+    assert hint["path_exists"] is False
 
 
 def test_upload_endpoint_stubbed(stubbed_client: TestClient) -> None:
@@ -99,3 +103,7 @@ def test_drive_diagnose_endpoint_stubbed(stubbed_client: TestClient) -> None:
     assert payload["projects"] == google_drive.STUB_FOLDERS
     assert payload["detail"] == google_drive.drive_service_error()
     assert payload["credentials_available"] is False
+    hint = payload["credentials_hint"]
+    assert hint["env_var_set"] is True
+    assert hint["expected_path"] == str(Path("/tmp/google-credentials-missing.json"))
+    assert hint["path_exists"] is False


### PR DESCRIPTION
## Summary
- capture detailed credential lookup hints inside the Drive service stub helpers
- expose the richer stub diagnostics via the health endpoint, Drive diagnose API, and startup logs
- expand the Drive stub regression tests to cover the new diagnostics payload

## Testing
- pytest backend/tests/test_drive_stubbed_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68dd3cc8ba80832a960f6b7bde0ee0de