### PR TITLE
Improve Render debugging setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,8 @@ docker compose up --build
 ### Project Mode
 - Default **Fixture Mode** (no Google Drive): `USE_FIXTURE_PROJECTS=true`
 - Live Google Drive Mode: set `USE_FIXTURE_PROJECTS=false` (requires Drive creds)
+
+### Render Debugging
+- Render Shell runs `render-build.sh` to provision Python (with dev tools) and Node 18 so you can debug both backend and frontend services.
+- After the build step completes you can activate the virtual environment with `source /opt/render/project/.venv/bin/activate` and run backend tasks.
+- Frontend dependencies are pre-installed via `npm ci`, letting you run `npm run dev` inside the shell for UI debugging.

--- a/render-build.sh
+++ b/render-build.sh
@@ -3,12 +3,33 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Install system packages required by the backend
-apt-get update     && apt-get install -y --no-install-recommends         libboost-all-dev         python3-venv     && rm -rf /var/lib/apt/lists/*
+# Install system packages required by the backend and debugging tools
+apt-get update
+apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    gnupg \
+    libboost-all-dev \
+    python3-venv
+
+# Install Node.js 18 for debugging the frontend when using Render Shell
+if ! command -v node >/dev/null 2>&1; then
+    curl -fsSL https://deb.nodesource.com/setup_18.x | bash -
+    apt-get install -y --no-install-recommends nodejs
+fi
+
+rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies inside a virtual environment for Render debugging
 VENV_PATH="/opt/render/project/.venv"
 python3 -m venv "$VENV_PATH"
 source "$VENV_PATH/bin/activate"
 pip install --upgrade pip
-pip install --no-cache-dir     -r backend/requirements.txt     -r backend/requirements-dev.txt
+pip install --no-cache-dir \
+    -r backend/requirements.txt \
+    -r backend/requirements-dev.txt
+
+# Install frontend dependencies for local debugging in Render Shell
+pushd frontend >/dev/null
+npm ci
+popd >/dev/null


### PR DESCRIPTION
## Summary
- expand render-build script to provision python, node, and frontend dependencies for Render Shell debugging
- document Render debugging workflow in the main README

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68dd41d0b1e8832a871e6781cca98a8e