### PR TITLE
Add Render debugging endpoint and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,16 @@ docker compose up --build
 ### Project Mode
 - Default **Fixture Mode** (no Google Drive): `USE_FIXTURE_PROJECTS=true`
 - Live Google Drive Mode: set `USE_FIXTURE_PROJECTS=false` (requires Drive creds)
+
+## Render deployment & debugging
+
+- **Build hook**: When using Render's native build environment, configure the
+  service to run `render-build.sh` so that system packages and Python
+  dependencies are installed inside a virtual environment optimised for remote
+  debugging.
+- **Start command**: The service runs `uvicorn backend.main:app` on port 8000;
+  logs printed during startup include Google Drive integration diagnostics to
+  confirm whether credentials are available.
+- **Debug endpoint**: `GET /api/debug/render` returns a JSON payload with Render
+  metadata (region, commit, host) and redacted connection details for PostgreSQL,
+  Redis, and the OpenAI API key to simplify environment validation.

--- a/backend/api/debug.py
+++ b/backend/api/debug.py
@@ -1,0 +1,76 @@
+"""Utility endpoints that expose Render-friendly debugging information."""
+
+from __future__ import annotations
+
+import os
+import platform
+import socket
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+from fastapi import APIRouter
+
+router = APIRouter(tags=["debug"])
+
+
+def _describe_connection_url(url: str | None) -> dict[str, Any]:
+    """Summarise the important parts of a connection string without secrets."""
+
+    if not url:
+        return {"present": False}
+
+    parsed = urlparse(url)
+    database = parsed.path.lstrip("/") or None
+
+    return {
+        "present": True,
+        "scheme": parsed.scheme,
+        "hostname": parsed.hostname,
+        "port": parsed.port,
+        "database": database,
+        "username_present": parsed.username is not None,
+    }
+
+
+def _bool_from_env(name: str, default: bool = False) -> bool:
+    """Parse boolean-like values Render commonly stores in env vars."""
+
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+
+    return raw.lower() in {"1", "true", "yes", "on"}
+
+
+@router.get("/debug/render", name="render_debug")
+def render_debug() -> dict[str, Any]:
+    """Return diagnostics that make Render deployments easier to debug."""
+
+    timestamp = datetime.now(tz=timezone.utc).isoformat()
+
+    database_url = os.getenv("DATABASE_URL")
+    redis_url = os.getenv("REDIS_URL")
+
+    return {
+        "status": "ok",
+        "generated_at": timestamp,
+        "environment": {
+            "render": bool(os.getenv("RENDER")),
+            "service": os.getenv("RENDER_SERVICE_ID"),
+            "region": os.getenv("RENDER_REGION"),
+            "git_commit": os.getenv("RENDER_GIT_COMMIT"),
+            "python_version": platform.python_version(),
+            "hostname": socket.gethostname(),
+        },
+        "features": {
+            "use_fixture_projects": _bool_from_env("USE_FIXTURE_PROJECTS", True),
+            "debug_logging": _bool_from_env("DEBUG", False),
+        },
+        "services": {
+            "database": _describe_connection_url(database_url),
+            "redis": _describe_connection_url(redis_url),
+            "openai_api_key_present": bool(os.getenv("OPENAI_API_KEY")),
+        },
+    }
+

--- a/backend/main.py
+++ b/backend/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from backend.api import (
     alerts,
     analytics,
+    debug,
     drive_diagnose,
     drive_scan,
     preferences,
@@ -35,6 +36,7 @@ app.include_router(drive_diagnose.router, prefix="/api")
 app.include_router(projects.router, prefix="/api")
 app.include_router(alerts.router, prefix="/api")
 app.include_router(analytics.router, prefix="/api")
+app.include_router(debug.router, prefix="/api")
 app.include_router(preferences.router, prefix="/api")
 app.include_router(upload.router, prefix="/api")
 app.include_router(speech.router, prefix="/api")

--- a/backend/tests/test_render_debug.py
+++ b/backend/tests/test_render_debug.py
@@ -1,0 +1,21 @@
+def test_render_debug_endpoint(client, monkeypatch):
+    monkeypatch.setenv("DATABASE_URL", "postgresql://user:pass@db:5432/app_db")
+    monkeypatch.setenv("REDIS_URL", "redis://:secret@redis:6379/0")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("RENDER", "true")
+    monkeypatch.setenv("RENDER_REGION", "oregon")
+    monkeypatch.setenv("USE_FIXTURE_PROJECTS", "false")
+    monkeypatch.setenv("DEBUG", "1")
+
+    response = client.get("/api/debug/render")
+
+    assert response.status_code == 200
+
+    payload = response.json()
+    assert payload["status"] == "ok"
+    assert payload["services"]["database"]["hostname"] == "db"
+    assert payload["services"]["database"]["database"] == "app_db"
+    assert payload["services"]["redis"]["scheme"] == "redis"
+    assert payload["services"]["openai_api_key_present"] is True
+    assert payload["features"]["use_fixture_projects"] is False
+    assert payload["features"]["debug_logging"] is True


### PR DESCRIPTION
## Summary
- add a FastAPI router that surfaces Render-focused diagnostics at `/api/debug/render`
- register the router with the application and document the endpoint in the README
- cover the new endpoint with a regression test to validate the response payload

## Testing
- `pytest backend/tests/test_render_debug.py backend/tests/test_health.py`


------
https://chatgpt.com/codex/tasks/task_e_68dd41d01118832ab45f59bdd1a21e0c