### PR TITLE
Include python3-venv in Render build script

### DIFF
--- a/README-QUICKSTART.md
+++ b/README-QUICKSTART.md
@@ -1,4 +1,3 @@
-
 # Masterise Brain AI — Quickstart
 
 ## Prereqs
@@ -36,3 +35,6 @@ Place YOLO weights into `backend/models/` (replace the `.pt.placeholder` files).
 ```bash
 API_BASE_URL=http://localhost:8000 python3 scripts/health_check.py
 ```
+## Render build
+If you need to run `render-build.sh` locally (for example to debug Render deployments), make sure the required system packages are installed via apt: `libboost-all-dev` and `python3-venv` (run `apt-get update` before installing if needed).
+

--- a/render-build.sh
+++ b/render-build.sh
@@ -4,7 +4,7 @@ set -o nounset
 set -o pipefail
 
 # Install system packages required by the backend
-apt-get update     && apt-get install -y --no-install-recommends         libboost-all-dev     && rm -rf /var/lib/apt/lists/*
+apt-get update     && apt-get install -y --no-install-recommends         libboost-all-dev         python3-venv     && rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies inside a virtual environment for Render debugging
 VENV_PATH="/opt/render/project/.venv"


### PR DESCRIPTION
## Summary
- add python3-venv to the Render build system packages so the virtual environment can be created reliably
- note the additional apt dependency in the quickstart guide for anyone running the Render build locally

## Testing
- bash render-build.sh

------
https://chatgpt.com/codex/tasks/task_e_68dd3afad9ec832aa22a570800116d69