### PR TITLE
Redesign chat interface with Diriyah-inspired theme

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,52 +1,611 @@
+@import url("https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600&family=Poppins:wght@500;600&display=swap");
 
 :root {
-  color-scheme: light dark;
-  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  background-color: #0f172a;
-  color: #e2e8f0;
+  font-family: "Inter", "Noto Sans", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  color: #2b211a;
+  background-color: #f5f0e6;
 }
 
-body { margin: 0; }
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
 
-.app {
-  min-height: 100vh;
-  padding: 3rem 1.5rem;
+body {
+  margin: 0;
+  background: #f5f0e6;
+  color: #2b211a;
+}
+
+button,
+select,
+textarea,
+input {
+  font-family: inherit;
+  color: inherit;
+}
+
+.app-shell {
+  display: grid;
+  grid-template-columns: 280px minmax(0, 1fr) 0;
+  height: 100vh;
+  background: #f5f0e6;
+  transition: grid-template-columns 0.3s ease;
+}
+
+.app-shell--panel-open {
+  grid-template-columns: 280px minmax(0, 1fr) 320px;
+}
+
+.sidebar {
   display: flex;
   flex-direction: column;
-  gap: 2rem;
-  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.2), transparent 55%),
-    radial-gradient(circle at bottom right, rgba(217, 70, 239, 0.18), transparent 50%),
-  #0f172a;
+  gap: 1.25rem;
+  padding: 1.75rem 1.5rem;
+  background: rgba(255, 253, 249, 0.95);
+  border-right: 1px solid #d8c7ac;
 }
-.app__header { text-align: center; }
-.app__title { font-size: clamp(2rem, 5vw, 3rem); margin-bottom: 0.25rem; }
-.app__subtitle { margin: 0; font-size: 1.1rem; color: #94a3b8; }
-.app__content { display: grid; gap: 1.5rem; max-width: 960px; margin: 0 auto; }
-.app__panel {
-  background: rgba(15, 23, 42, 0.75);
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  border-radius: 1rem;
-  padding: 1.75rem;
-  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.65);
+
+.sidebar__logo {
+  font-family: "Poppins", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 1.35rem;
+  color: #3f2f23;
 }
-.app__panel h2 { margin-top: 0; margin-bottom: 0.75rem; }
-.app__panel p { line-height: 1.6; margin-bottom: 1rem; }
-.app__panel ol { margin: 0; padding-left: 1.25rem; line-height: 1.6; }
-.app__actions { display: flex; flex-wrap: wrap; gap: 0.75rem; }
-.app__link {
-  color: inherit;
-  background: rgba(148, 163, 184, 0.1);
-  border: 1px solid rgba(148, 163, 184, 0.25);
+
+.sidebar__section {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.sidebar__label {
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: #7a6a57;
+}
+
+.sidebar__dropdown {
+  width: 100%;
+  padding: 0.65rem 0.85rem;
+  border-radius: 10px;
+  border: 1px solid #d8c7ac;
+  background: #fff9f0;
+  color: #2b211a;
+  appearance: none;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sidebar__dropdown:focus {
+  border-color: #c8a165;
+  box-shadow: 0 0 0 3px rgba(200, 161, 101, 0.25);
+}
+
+.sidebar__chats {
+  flex: 1;
+  overflow: hidden;
+}
+
+.sidebar__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  margin-bottom: 1rem;
+}
+
+.sidebar__group-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  padding: 0.35rem 0;
+  border: none;
+  background: transparent;
+  color: #6f604e;
+  font-size: 0.82rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.sidebar__group-caret {
+  font-size: 0.85rem;
+}
+
+.sidebar__chat-list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  max-height: 320px;
+  overflow: hidden;
+  transition: max-height 0.25s ease, opacity 0.25s ease;
+}
+
+.sidebar__chat-list--collapsed {
+  max-height: 0;
+  opacity: 0;
+}
+
+.sidebar__chat-button {
+  width: 100%;
+  border: none;
+  background: rgba(239, 230, 214, 0.6);
+  border-radius: 12px;
+  padding: 0.6rem 0.75rem;
+  text-align: left;
+  font-size: 0.95rem;
+  color: #3f3329;
+  cursor: pointer;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.sidebar__chat-button:hover,
+.sidebar__chat-button:focus {
+  background: rgba(222, 206, 185, 0.9);
+  box-shadow: 0 6px 18px rgba(47, 35, 24, 0.1);
+  outline: none;
+}
+
+.sidebar__bottom {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 0.75rem;
+  padding-top: 1.5rem;
+  border-top: 1px solid rgba(216, 199, 172, 0.6);
+}
+
+.sidebar__icon {
+  width: 42px;
+  height: 42px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  background: rgba(239, 230, 214, 0.75);
+  color: #6b5c4c;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.sidebar__icon:hover,
+.sidebar__icon:focus {
+  background: rgba(222, 206, 185, 0.95);
+  border-color: #c8a165;
+  outline: none;
+}
+
+.chat {
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(180deg, rgba(247, 240, 228, 0.65), rgba(245, 240, 230, 0.95));
+}
+
+.chat__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.25rem 1.75rem;
+  border-bottom: 1px solid rgba(216, 199, 172, 0.65);
+  background: rgba(255, 252, 245, 0.85);
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  backdrop-filter: blur(8px);
+}
+
+.chat__project-name {
+  font-family: "Poppins", "Inter", sans-serif;
+  font-weight: 600;
+  font-size: 1.25rem;
+}
+
+.chat__project-meta {
+  font-size: 0.85rem;
+  color: #7a6a57;
+  margin-top: 0.2rem;
+}
+
+.chat__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.chat__status {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #c8a165;
+  box-shadow: 0 0 0 4px rgba(200, 161, 101, 0.15);
+}
+
+.chat__status--connected {
+  background: #3f7d4c;
+  box-shadow: 0 0 0 4px rgba(63, 125, 76, 0.18);
+}
+
+.chat__context-toggle {
+  border: 1px solid #d8c7ac;
+  background: rgba(239, 230, 214, 0.65);
+  color: #5c4e3f;
   border-radius: 999px;
-  padding: 0.5rem 1.25rem;
-  text-decoration: none;
-  transition: background-color 0.2s ease, transform 0.2s ease;
+  padding: 0.4rem 1.1rem;
+  font-size: 0.9rem;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease;
 }
-.app__link:hover,
-.app__link:focus {
-  background: rgba(148, 163, 184, 0.25);
-  transform: translateY(-1px);
+
+.chat__context-toggle:hover,
+.chat__context-toggle:focus {
+  background: rgba(222, 206, 185, 0.95);
+  border-color: #c8a165;
+  outline: none;
 }
-@media (min-width: 768px) {
-  .app__content { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+
+.chat__window {
+  flex: 1;
+  overflow-y: auto;
+  padding: 1.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.75rem;
+}
+
+.chat__day-group {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.chat__date-divider {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  color: #7a6a57;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+.chat__date-divider::before,
+.chat__date-divider::after {
+  content: "";
+  flex: 1;
+  height: 1px;
+  background: rgba(216, 199, 172, 0.5);
+}
+
+.chat__msg {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.5rem;
+}
+
+.chat__msg--user {
+  align-items: flex-end;
+}
+
+.chat__bubble {
+  max-width: 60ch;
+  padding: 0.85rem 1.1rem;
+  border-radius: 16px;
+  background: rgba(208, 190, 163, 0.65);
+  color: #2b211a;
+  line-height: 1.5;
+  box-shadow: 0 12px 24px rgba(43, 33, 26, 0.08);
+}
+
+.chat__msg--user .chat__bubble {
+  background: rgba(245, 236, 221, 0.95);
+  box-shadow: 0 14px 28px rgba(82, 64, 47, 0.12);
+}
+
+.chat__meta {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  font-size: 0.8rem;
+  color: #7a6a57;
+}
+
+.chat__msg--user .chat__meta {
+  justify-content: flex-end;
+}
+
+.chat__actions {
+  display: flex;
+  gap: 0.75rem;
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.2s ease;
+}
+
+.chat__msg:hover .chat__actions,
+.chat__msg:focus-within .chat__actions {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.chat__actions button {
+  border: none;
+  background: none;
+  color: #6f604e;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.chat__actions button:hover,
+.chat__actions button:focus {
+  color: #3f2f23;
+  outline: none;
+}
+
+.chat__composer {
+  padding: 1.25rem 1.75rem 1.5rem;
+  border-top: 1px solid rgba(216, 199, 172, 0.65);
+  background: linear-gradient(180deg, rgba(255, 252, 245, 0.9), rgba(245, 240, 230, 0.95));
+}
+
+.chat__composer-inner {
+  display: flex;
+  align-items: flex-end;
+  gap: 1rem;
+  padding: 0.75rem 1rem;
+  background: #fffdf9;
+  border: 1px solid rgba(216, 199, 172, 0.9);
+  border-radius: 18px;
+  box-shadow: 0 16px 32px rgba(43, 33, 26, 0.08);
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat__composer-inner:focus-within {
+  border-color: #c8a165;
+  box-shadow: 0 18px 36px rgba(43, 33, 26, 0.1);
+}
+
+.chat__composer textarea {
+  flex: 1;
+  min-height: 2.5rem;
+  max-height: 160px;
+  resize: none;
+  border: none;
+  background: transparent;
+  font-size: 1rem;
+  line-height: 1.5;
+  color: #2b211a;
+  outline: none;
+}
+
+.chat__controls {
+  display: flex;
+  align-items: center;
+  gap: 0.65rem;
+}
+
+.chat__attachments {
+  display: flex;
+  align-items: center;
+  gap: 0.45rem;
+  opacity: 0;
+  transform: translateY(4px);
+  pointer-events: none;
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.chat__composer-inner:hover .chat__attachments,
+.chat__composer-inner:focus-within .chat__attachments {
+  opacity: 1;
+  pointer-events: auto;
+  transform: translateY(0);
+}
+
+.chat__attachments button {
+  width: 34px;
+  height: 34px;
+  border-radius: 50%;
+  border: 1px solid transparent;
+  background: rgba(239, 230, 214, 0.65);
+  color: #6f604e;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.chat__attachments button:hover,
+.chat__attachments button:focus {
+  background: rgba(222, 206, 185, 0.95);
+  border-color: #c8a165;
+  color: #3f2f23;
+  outline: none;
+}
+
+.chat__hidden-input {
+  display: none;
+}
+
+.chat__mic {
+  width: 38px;
+  height: 38px;
+  border-radius: 50%;
+  border: 1px solid rgba(216, 199, 172, 0.9);
+  background: rgba(255, 252, 245, 0.95);
+  color: #6f604e;
+  display: grid;
+  place-items: center;
+  cursor: pointer;
+  transition: background 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.chat__mic:hover,
+.chat__mic:focus {
+  background: rgba(222, 206, 185, 0.95);
+  border-color: #c8a165;
+  color: #3f2f23;
+  outline: none;
+}
+
+.chat__mic--disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.chat__send {
+  padding: 0.55rem 1.4rem;
+  border-radius: 999px;
+  border: none;
+  background: #c8a165;
+  color: #fff;
+  font-weight: 500;
+  cursor: pointer;
+  box-shadow: 0 12px 24px rgba(200, 161, 101, 0.35);
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.chat__send:hover,
+.chat__send:focus {
+  background: #b4894f;
+  box-shadow: 0 14px 28px rgba(180, 137, 79, 0.4);
+  outline: none;
+}
+
+.chat__mic-warning {
+  margin-top: 0.75rem;
+  font-size: 0.8rem;
+  color: #9c7f58;
+}
+
+.context-panel {
+  overflow: hidden;
+  background: rgba(255, 252, 245, 0.98);
+  border-left: 1px solid rgba(216, 199, 172, 0.65);
+  padding: 1.75rem 1.5rem;
+  box-shadow: -12px 0 32px rgba(43, 33, 26, 0.08);
+  pointer-events: none;
+  opacity: 0;
+  transform: translateX(20px);
+  transition: opacity 0.3s ease, transform 0.3s ease;
+}
+
+.app-shell--panel-open .context-panel {
+  pointer-events: auto;
+  opacity: 1;
+  transform: translateX(0);
+}
+
+.context-panel__tabs {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+
+.context-panel__tabs button {
+  border: 1px solid transparent;
+  border-radius: 12px;
+  padding: 0.6rem 0.5rem;
+  background: rgba(239, 230, 214, 0.6);
+  color: #5c4e3f;
+  cursor: pointer;
+  font-size: 0.85rem;
+  transition: background 0.2s ease, border-color 0.2s ease;
+}
+
+.context-panel__tabs button[aria-selected="true"],
+.context-panel__tabs button:hover,
+.context-panel__tabs button:focus {
+  background: rgba(222, 206, 185, 0.95);
+  border-color: #c8a165;
+  outline: none;
+}
+
+.context-panel__content {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  color: #4c3e30;
+}
+
+.context-panel__content h3 {
+  font-family: "Poppins", "Inter", sans-serif;
+  font-weight: 600;
+  margin: 0;
+}
+
+.context-panel__content p {
+  margin: 0;
+  line-height: 1.6;
+}
+
+.icon__svg {
+  width: 20px;
+  height: 20px;
+  stroke: currentColor;
+}
+
+.icon__svg--active {
+  color: #c18c4a;
+}
+
+.chat__window::-webkit-scrollbar,
+.sidebar::-webkit-scrollbar {
+  width: 8px;
+}
+
+.chat__window::-webkit-scrollbar-track,
+.sidebar::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.chat__window::-webkit-scrollbar-thumb,
+.sidebar::-webkit-scrollbar-thumb {
+  background: rgba(165, 147, 123, 0.5);
+  border-radius: 999px;
+}
+
+@media (max-width: 1200px) {
+  .app-shell {
+    grid-template-columns: 240px minmax(0, 1fr) 0;
+  }
+
+  .app-shell--panel-open {
+    grid-template-columns: 240px minmax(0, 1fr) 300px;
+  }
+}
+
+@media (max-width: 960px) {
+  .app-shell,
+  .app-shell--panel-open {
+    grid-template-columns: 0 minmax(0, 1fr) 0;
+  }
+
+  .sidebar {
+    display: none;
+  }
+
+  .context-panel {
+    display: none;
+  }
+
+  .chat__header {
+    padding: 1rem 1.25rem;
+  }
+
+  .chat__window {
+    padding: 1.25rem;
+  }
+
+  .chat__composer {
+    padding: 1rem 1.25rem 1.25rem;
+  }
 }

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,39 +1,514 @@
+import { useMemo, useRef, useState } from "react";
 import "./App.css";
 
+const seededMessages = [
+  {
+    id: "m-1",
+    role: "ai",
+    content: "Welcome to Diriyah Brain AI. Select a project to begin reviewing today's activities.",
+    timestamp: new Date("2024-09-18T09:41:00"),
+  },
+  {
+    id: "m-2",
+    role: "user",
+    content: "Summarise the open structural actions for Villa 100.",
+    timestamp: new Date("2024-09-18T09:43:00"),
+  },
+  {
+    id: "m-3",
+    role: "ai",
+    content:
+      "Villa 100 has three open actions: podium slab pour pending procurement sign-off, façade mock-up review scheduled Thursday, and workforce ramp-up approval awaiting HR.",
+    timestamp: new Date("2024-09-18T09:44:00"),
+  },
+  {
+    id: "m-4",
+    role: "user",
+    content: "Flag the procurement risk for the podium slab and notify the commercial lead.",
+    timestamp: new Date("2024-09-17T17:21:00"),
+  },
+  {
+    id: "m-5",
+    role: "ai",
+    content:
+      "Risk flagged. Notification drafted to commercial lead with revised delivery timeline and escalation note.",
+    timestamp: new Date("2024-09-17T17:22:00"),
+  },
+];
+
+const chatGroups = [
+  {
+    id: "today",
+    label: "Today",
+    conversations: ["Villa 100 — Casting Delay", "Gateway Villas — Concrete Pour"],
+  },
+  {
+    id: "week",
+    label: "This Week",
+    conversations: ["Downtown Tower — Procurement", "Cultural District — Logistics"],
+  },
+  {
+    id: "archive",
+    label: "Previous",
+    conversations: ["Residences — Snag Review", "Retail Spine — Fit-Out"],
+  },
+];
+
+const projects = ["Gateway Villas", "Downtown Towers", "Villa 100", "Cultural District"];
+
+const formatDate = (date) =>
+  new Intl.DateTimeFormat("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  }).format(date);
+
+const formatTime = (date) =>
+  new Intl.DateTimeFormat("en-US", {
+    hour: "2-digit",
+    minute: "2-digit",
+  }).format(date);
+
+const IconSettings = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" className="icon__svg">
+    <path
+      d="M12 15.5a3.5 3.5 0 1 0 0-7 3.5 3.5 0 0 0 0 7Zm8.5-3.5a6.82 6.82 0 0 0-.08-1l2.11-1.65-2-3.46-2.5.63a6.88 6.88 0 0 0-1.72-1l-.38-2.54H9.57l-.38 2.54a6.88 6.88 0 0 0-1.72 1l-2.5-.63-2 3.46 2.11 1.65a6.82 6.82 0 0 0 0 2l-2.11 1.65 2 3.46 2.5-.63a6.88 6.88 0 0 0 1.72 1l.38 2.54h4.74l.38-2.54a6.88 6.88 0 0 0 1.72-1l2.5.63 2-3.46-2.11-1.65a6.82 6.82 0 0 0 .08-1Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconFileText = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" className="icon__svg">
+    <path
+      d="M6 2.75h7.19a2 2 0 0 1 1.41.59l3.06 3.06a2 2 0 0 1 .59 1.41v12.44A1.75 1.75 0 0 1 16.5 22.25h-9A1.75 1.75 0 0 1 5.75 20.5V4.5A1.75 1.75 0 0 1 7.5 2.75"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M13.5 2.75V7h4.25"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M9 12.25h6M9 15.75h6" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" />
+  </svg>
+);
+
+const IconUser = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" className="icon__svg">
+    <path
+      d="M12 12.75a4.5 4.5 0 1 0-4.5-4.5 4.5 4.5 0 0 0 4.5 4.5Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.75 19.5a7.25 7.25 0 0 1 14.5 0"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconUpload = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" className="icon__svg">
+    <path
+      d="M12 15.25V4.75M8.75 8.25 12 4.75l3.25 3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M4.75 15.25v3.5a1.5 1.5 0 0 0 1.5 1.5h11.5a1.5 1.5 0 0 0 1.5-1.5v-3.5"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconCamera = () => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" className="icon__svg">
+    <path
+      d="M21.25 17.5a1.75 1.75 0 0 1-1.75 1.75H4.5A1.75 1.75 0 0 1 2.75 17.5v-8a1.75 1.75 0 0 1 1.75-1.75h2.12l1.2-1.94a1 1 0 0 1 .85-.46h4.36a1 1 0 0 1 .85.46l1.2 1.94h2.12a1.75 1.75 0 0 1 1.75 1.75Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M12 15.75a3 3 0 1 0-3-3 3 3 0 0 0 3 3Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
+const IconMic = ({ active }) => (
+  <svg viewBox="0 0 24 24" aria-hidden="true" className={`icon__svg ${active ? "icon__svg--active" : ""}`}>
+    <path
+      d="M12 15.75a3.25 3.25 0 0 0 3.25-3.25V6.75A3.25 3.25 0 0 0 12 3.5a3.25 3.25 0 0 0-3.25 3.25v5.75A3.25 3.25 0 0 0 12 15.75Z"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path
+      d="M5.75 11.5v1a6.25 6.25 0 0 0 12.5 0v-1M12 18.5v2.75"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+  </svg>
+);
+
 function App() {
+  const [selectedProject, setSelectedProject] = useState(projects[0]);
+  const [messages, setMessages] = useState(seededMessages);
+  const [input, setInput] = useState("");
+  const [collapsedGroups, setCollapsedGroups] = useState(() =>
+    chatGroups.reduce((acc, group) => ({ ...acc, [group.id]: false }), {})
+  );
+  const [isPanelOpen, setIsPanelOpen] = useState(false);
+  const [isListening, setIsListening] = useState(false);
+  const [micSupported, setMicSupported] = useState(true);
+  const recognitionRef = useRef(null);
+  const uploadInputRef = useRef(null);
+  const cameraInputRef = useRef(null);
+
+  const groupedMessages = useMemo(() => {
+    const ordered = [...messages].sort((a, b) => a.timestamp - b.timestamp);
+    const map = new Map();
+
+    ordered.forEach((message) => {
+      const key = formatDate(message.timestamp);
+      if (!map.has(key)) {
+        map.set(key, []);
+      }
+      map.get(key).push(message);
+    });
+
+    return Array.from(map.entries());
+  }, [messages]);
+
+  const sendMessage = () => {
+    if (!input.trim()) {
+      return;
+    }
+
+    const entry = {
+      id: `m-${Date.now()}`,
+      role: "user",
+      content: input.trim(),
+      timestamp: new Date(),
+    };
+
+    setMessages((prev) => [...prev, entry]);
+    setInput("");
+  };
+
+  const toggleGroup = (id) => {
+    setCollapsedGroups((prev) => ({ ...prev, [id]: !prev[id] }));
+  };
+
+  const toggleContextPanel = () => {
+    setIsPanelOpen((prev) => !prev);
+  };
+
+  const handleUpload = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const message = {
+      id: `m-${Date.now()}-upload`,
+      role: "ai",
+      content: `Indexed file: ${file.name} (metadata captured).`,
+      timestamp: new Date(),
+    };
+
+    setMessages((prev) => [...prev, message]);
+    event.target.value = "";
+  };
+
+  const handleMicToggle = () => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const SpeechRecognition =
+      window.SpeechRecognition || window.webkitSpeechRecognition;
+
+    if (!SpeechRecognition) {
+      setMicSupported(false);
+      return;
+    }
+
+    if (isListening) {
+      recognitionRef.current?.stop();
+      return;
+    }
+
+    const recognition = recognitionRef.current ?? new SpeechRecognition();
+    recognition.continuous = false;
+    recognition.interimResults = false;
+    recognition.lang = "en-US";
+
+    recognition.onresult = (event) => {
+      const transcript = event.results[0][0]?.transcript;
+      if (transcript) {
+        setInput((prev) => `${prev ? `${prev} ` : ""}${transcript}`.trimStart());
+      }
+    };
+
+    recognition.onerror = () => {
+      setIsListening(false);
+    };
+
+    recognition.onend = () => {
+      setIsListening(false);
+    };
+
+    recognitionRef.current = recognition;
+    setIsListening(true);
+    recognition.start();
+  };
+
+  const handleCameraCapture = (event) => {
+    const file = event.target.files?.[0];
+    if (!file) {
+      return;
+    }
+
+    const message = {
+      id: `m-${Date.now()}-camera`,
+      role: "ai",
+      content: `Image captured: ${file.name || "new photo"} (insights pending).`,
+      timestamp: new Date(),
+    };
+
+    setMessages((prev) => [...prev, message]);
+    event.target.value = "";
+  };
+
+  const projectStatus = {
+    tone: "connected",
+    label: "Connected",
+  };
+
   return (
-    <div className="app">
-      <header className="app__header">
-        <h1 className="app__title">Diriyah AI Demo</h1>
-        <p className="app__subtitle">Stub administrative console</p>
-      </header>
+    <div className={`app-shell ${isPanelOpen ? "app-shell--panel-open" : ""}`}>
+      <aside className="sidebar" aria-label="Conversations sidebar">
+        <div className="sidebar__logo">Diriyah Brain AI</div>
 
-      <main className="app__content">
-        <section className="app__panel">
-          <h2>Deployment ready UI</h2>
-          <p>
-            The production Docker image now ships with the compiled frontend bundle so
-            the FastAPI backend can serve the single-page app directly. Use the
-            buttons below to verify the health of the stack or rebuild the bundle
-            when iterating locally.
-          </p>
-          <div className="app__actions">
-            <a className="app__link" href="/health">Backend health check</a>
-            <a className="app__link" href="https://render.com/docs" target="_blank" rel="noreferrer">
-              Render documentation
-            </a>
+        <div className="sidebar__section">
+          <label htmlFor="project-select" className="sidebar__label">
+            Project workspace
+          </label>
+          <select
+            id="project-select"
+            className="sidebar__dropdown"
+            value={selectedProject}
+            onChange={(event) => setSelectedProject(event.target.value)}
+          >
+            {projects.map((project) => (
+              <option key={project} value={project}>
+                {project}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <nav className="sidebar__section sidebar__chats" aria-label="Chat history">
+          {chatGroups.map((group) => (
+            <div key={group.id} className="sidebar__group">
+              <button
+                type="button"
+                className="sidebar__group-toggle"
+                onClick={() => toggleGroup(group.id)}
+                aria-expanded={!collapsedGroups[group.id]}
+              >
+                <span>{group.label}</span>
+                <span className="sidebar__group-caret" aria-hidden="true">
+                  {collapsedGroups[group.id] ? "▸" : "▾"}
+                </span>
+              </button>
+              <ul
+                className={`sidebar__chat-list ${collapsedGroups[group.id] ? "sidebar__chat-list--collapsed" : ""}`}
+              >
+                {group.conversations.map((conversation) => (
+                  <li key={conversation}>
+                    <button type="button" className="sidebar__chat-button">
+                      {conversation}
+                    </button>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </nav>
+
+        <div className="sidebar__bottom" aria-label="Workspace settings">
+          <button type="button" className="sidebar__icon" aria-label="Settings">
+            <IconSettings />
+          </button>
+          <button type="button" className="sidebar__icon" aria-label="Documentation">
+            <IconFileText />
+          </button>
+          <button type="button" className="sidebar__icon" aria-label="Profile">
+            <IconUser />
+          </button>
+        </div>
+      </aside>
+
+      <main className="chat" aria-label="Chat panel">
+        <header className="chat__header">
+          <div className="chat__project">
+            <div className="chat__project-name">{selectedProject}</div>
+            <div className="chat__project-meta">Central delivery workspace</div>
           </div>
-        </section>
+          <div className="chat__header-actions">
+            <span className={`chat__status chat__status--${projectStatus.tone}`} aria-label={projectStatus.label} />
+            <button type="button" className="chat__context-toggle" onClick={toggleContextPanel}>
+              Context
+            </button>
+          </div>
+        </header>
 
-        <section className="app__panel">
-          <h2>Getting started</h2>
-          <ol>
-            <li>Run <code>npm run dev</code> inside the <code>frontend</code> folder for hot reloads.</li>
-            <li>Execute <code>npm run build</code> before pushing to confirm the static bundle.</li>
-            <li>Start the API with <code>uvicorn backend.main:app --reload</code> to develop end-to-end.</li>
-          </ol>
-        </section>
+        <div className="chat__window" aria-live="polite">
+          {groupedMessages.map(([dateLabel, items]) => (
+            <div key={dateLabel} className="chat__day-group">
+              <div className="chat__date-divider">
+                <span>{dateLabel}</span>
+              </div>
+              {items.map((message) => (
+                <article key={message.id} className={`chat__msg chat__msg--${message.role}`}>
+                  <div className="chat__bubble">
+                    <p>{message.content}</p>
+                  </div>
+                  <footer className="chat__meta">
+                    <time className="chat__time" dateTime={message.timestamp.toISOString()}>
+                      {formatTime(message.timestamp)}
+                    </time>
+                    <div className="chat__actions" role="group" aria-label="Message actions">
+                      <button type="button">Copy</button>
+                      <button type="button">Pin</button>
+                      <button type="button">Flag</button>
+                    </div>
+                  </footer>
+                </article>
+              ))}
+            </div>
+          ))}
+        </div>
+
+        <div className="chat__composer" aria-label="Message composer">
+          <div className="chat__composer-inner">
+            <textarea
+              placeholder="Share an update or ask Diriyah Brain AI to analyse project data..."
+              value={input}
+              onChange={(event) => setInput(event.target.value)}
+              onKeyDown={(event) => {
+                if (event.key === "Enter" && !event.shiftKey) {
+                  event.preventDefault();
+                  sendMessage();
+                }
+              }}
+              rows={1}
+            />
+            <div className="chat__controls">
+              <div className="chat__attachments">
+                <input
+                  type="file"
+                  ref={uploadInputRef}
+                  className="chat__hidden-input"
+                  onChange={handleUpload}
+                />
+                <button type="button" onClick={() => uploadInputRef.current?.click()} aria-label="Upload file">
+                  <IconUpload />
+                </button>
+                <input
+                  type="file"
+                  accept="image/*"
+                  capture="environment"
+                  ref={cameraInputRef}
+                  className="chat__hidden-input"
+                  onChange={handleCameraCapture}
+                />
+                <button type="button" onClick={() => cameraInputRef.current?.click()} aria-label="Capture image">
+                  <IconCamera />
+                </button>
+              </div>
+              <button
+                type="button"
+                className={`chat__mic ${!micSupported ? "chat__mic--disabled" : ""}`}
+                onClick={handleMicToggle}
+                disabled={!micSupported}
+                aria-pressed={isListening}
+              >
+                <IconMic active={isListening} />
+              </button>
+              <button type="button" className="chat__send" onClick={sendMessage}>
+                Send
+              </button>
+            </div>
+          </div>
+          {!micSupported && (
+            <p className="chat__mic-warning">Speech capture is not available in this browser.</p>
+          )}
+        </div>
       </main>
+
+      <aside className={`context-panel ${isPanelOpen ? "context-panel--open" : ""}`} aria-label="Context panel">
+        <div className="context-panel__tabs" role="tablist">
+          <button type="button" role="tab" aria-selected="true">
+            Documents
+          </button>
+          <button type="button" role="tab" aria-selected="false">
+            Drawings
+          </button>
+          <button type="button" role="tab" aria-selected="false">
+            Schedules
+          </button>
+          <button type="button" role="tab" aria-selected="false">
+            Contracts
+          </button>
+        </div>
+        <div className="context-panel__content">
+          <h3>Project context</h3>
+          <p>
+            Summaries and risk dashboards from Google Drive, Aconex, and Primavera will appear here when the
+            workspace is engaged.
+          </p>
+        </div>
+      </aside>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- replace the placeholder console with a Diriyah Brain AI chat workspace styled after ChatGPT
- add collapsible chat history, subtle attachment controls, and a toggleable context panel to mirror the requested UX
- include microphone, upload, and camera handlers with graceful fallbacks and the Najdi beige palette

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dd4e367098832a9600791122a99263