### PR TITLE
Serve frontend UI through FastAPI root endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,7 @@ RUN pip install --no-cache-dir -r backend/requirements.txt
 
 # Copy project code and runtime assets
 COPY backend /app/backend
+COPY frontend/public /app/frontend/public
 RUN mkdir -p /app/uploads /app/images /app/storage
 # Include the compiled frontend bundle
 COPY --from=frontend-build /frontend/dist /app/frontend_dist

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,6 +27,7 @@ RUN pip install --no-cache-dir -r /app/backend/requirements.txt \
     gunicorn==21.2.0
 
 COPY backend /app/backend
+COPY frontend/public /app/frontend/public
 RUN mkdir -p /app/uploads /app/images /app/storage
 COPY --from=frontend-build /frontend/dist /app/frontend_dist
 

--- a/render.yaml
+++ b/render.yaml
@@ -5,8 +5,8 @@ services:
     env: docker
     plan: starter
     branch: main
-    buildCommand: docker build -t mba-backend .
-    startCommand: bash -c "uvicorn backend.main:app --host 0.0.0.0 --port 8000"
+    buildCommand: docker build -f backend/Dockerfile -t mba-backend .
+    startCommand: bash -c "gunicorn -k uvicorn.workers.UvicornWorker -w 4 -b 0.0.0.0:8000 backend.main:app"
     envVars:
       - key: OPENAI_API_KEY
         sync: false


### PR DESCRIPTION
## Summary
- add a root FastAPI route that serves the built frontend HTML and static assets
- mount the frontend static directories so logos and bundles are available
- copy the frontend bundle into the Docker images and update Render to build from the backend Dockerfile

## Testing
- pytest *(fails: drive stub endpoints currently return HTTP 404)*

------
https://chatgpt.com/codex/tasks/task_e_68de763911c8832a86ed593fa42cdbbf