### PR TITLE
Implement analytics services and meeting summaries

### DIFF
--- a/backend/api/analytics.py
+++ b/backend/api/analytics.py
@@ -1,4 +1,150 @@
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Dict, List
+
 from fastapi import APIRouter
+
+from backend.services.anomaly_detector import detect_anomalies
+from backend.services.compliance_monitor import check_compliance
+
 router = APIRouter()
+
+
+_SAMPLE_STREAM: List[Dict[str, Any]] = [
+    {
+        "timestamp": "2024-04-01T09:00:00Z",
+        "section": "Structure",
+        "risk_score": 0.82,
+        "risk_threshold": 0.6,
+        "risk_drivers": ["supply chain", "weather"],
+        "progress_percent": 45,
+        "expected_progress_percent": 52,
+        "schedule_delay_days": 4,
+        "notes": "Concrete curing slower because of humidity.",
+    },
+    {
+        "timestamp": "2024-04-03T15:00:00Z",
+        "section": "Safety",
+        "incidents": 2,
+        "notes": "Two slip incidents recorded on scaffold, no lost time.",
+    },
+    {
+        "timestamp": "2024-04-05T12:30:00Z",
+        "section": "Commercial",
+        "planned_cost": 1_200_000,
+        "actual_cost": 1_320_000,
+        "cost_tolerance_pct": 5,
+        "notes": "Steel price surge impacted procurement package.",
+    },
+    {
+        "timestamp": "2024-04-06T18:00:00Z",
+        "section": "Schedule",
+        "milestone": "Podium completion",
+        "days_late": 5,
+        "notes": "Awaiting façade bracket delivery for final pour.",
+    },
+]
+
+_SAMPLE_COMPLIANCE_TEXT = (
+    "Updated construction safety plan covers PPE requirements and emergency response. "
+    "Weekly inspections recorded in the log. Hot work permits pending signature from fire marshal."
+)
+
+_SAMPLE_RULES = [
+    {
+        "id": "safety-plan",
+        "description": "Safety plan must outline PPE and emergency response steps",
+        "required_phrases": ["safety plan", "emergency response"],
+        "severity": "high",
+    },
+    {
+        "id": "inspection-cadence",
+        "description": "Inspection cadence should mention weekly frequency",
+        "required_phrases": ["weekly inspections"],
+        "severity": "medium",
+    },
+    {
+        "id": "permit-approval",
+        "description": "Hot work permits must be approved prior to execution",
+        "forbidden_phrases": ["pending signature"],
+        "severity": "high",
+        "recommendation": "Escalate with the fire marshal for immediate approval.",
+    },
+]
+
+
 @router.get("/analytics/summary")
-def analytics_summary(): return {"status":"ok","data":{"risk":"N/A","progress":"N/A"}}
+def analytics_summary() -> Dict[str, Any]:
+    """Provide a deterministic analytics snapshot for local development."""
+
+    anomalies = detect_anomalies(_SAMPLE_STREAM)
+    compliance_findings = check_compliance(_SAMPLE_COMPLIANCE_TEXT, _SAMPLE_RULES)
+
+    risk_alerts = [finding for finding in anomalies if finding["type"] == "risk"]
+    schedule_alerts = [finding for finding in anomalies if finding["type"] == "schedule"]
+    safety_alerts = [finding for finding in anomalies if finding["type"] == "safety"]
+    cost_alerts = [finding for finding in anomalies if finding["type"] == "cost"]
+
+    latest_progress = _latest_progress(_SAMPLE_STREAM)
+    compliance_breaches = [finding for finding in compliance_findings if finding["status"] != "compliant"]
+
+    overall_health = _determine_overall_health(risk_alerts, schedule_alerts, safety_alerts, compliance_breaches)
+
+    return {
+        "status": "ok",
+        "generatedAt": datetime.utcnow().isoformat(timespec="seconds") + "Z",
+        "data": {
+            "overallHealth": overall_health,
+            "riskAlerts": len(risk_alerts),
+            "safetyIncidents": sum(alert["context"].get("incident_count", 1) for alert in safety_alerts),
+            "scheduleVarianceDays": _aggregate_schedule_variance(schedule_alerts),
+            "costVariancePct": round(sum(alert["context"].get("deviation_pct", 0.0) for alert in cost_alerts), 1),
+            "latestProgress": latest_progress,
+            "complianceBreaches": len(compliance_breaches),
+            "nonCompliantRules": [finding["rule_id"] for finding in compliance_breaches],
+        },
+        "anomalies": anomalies,
+        "compliance": compliance_findings,
+    }
+
+
+def _latest_progress(stream: List[Dict[str, Any]]) -> Dict[str, float]:
+    latest_entry = None
+    for entry in stream:
+        if "progress_percent" not in entry:
+            continue
+        latest_entry = entry
+    if not latest_entry:
+        return {"actual": 0.0, "expected": 0.0}
+    return {
+        "actual": float(latest_entry.get("progress_percent", 0.0)),
+        "expected": float(latest_entry.get("expected_progress_percent", 0.0)),
+    }
+
+
+def _aggregate_schedule_variance(schedule_alerts: List[Dict[str, Any]]) -> int:
+    total = 0.0
+    for alert in schedule_alerts:
+        if "delay_days" in alert["context"]:
+            total += float(alert["context"].get("delay_days", 0.0))
+        elif "variance_percent" in alert["context"]:
+            # Convert percentage variance into rough day equivalent assuming a
+            # five-day working week; this keeps the stub realistic for dashboards.
+            total += float(alert["context"].get("variance_percent", 0.0)) / 100 * 5
+    return int(round(total))
+
+
+def _determine_overall_health(
+    risk_alerts: List[Dict[str, Any]],
+    schedule_alerts: List[Dict[str, Any]],
+    safety_alerts: List[Dict[str, Any]],
+    compliance_breaches: List[Dict[str, Any]],
+) -> str:
+    if any(alert["severity"] == "critical" for alert in (*risk_alerts, *schedule_alerts, *safety_alerts)):
+        return "at-risk"
+    if compliance_breaches and any(breach["severity"] == "high" for breach in compliance_breaches):
+        return "attention"
+    if risk_alerts or schedule_alerts or safety_alerts:
+        return "watch"
+    return "on-track"

--- a/backend/services/anomaly_detector.py
+++ b/backend/services/anomaly_detector.py
@@ -1,1 +1,242 @@
-def detect_anomalies(data_stream: list): return []
+"""Rule based anomaly detection for construction telemetry.
+
+The helper inspects heterogenous dictionaries coming from planning,
+operations and safety systems.  It looks for well known signals that
+should trigger follow-up by the analytics dashboard and returns a list
+of structured findings.  The implementation purposely favours clear
+heuristics over statistical models so the behaviour is predictable in
+tests and for debugging inside Render deployments.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+
+Severity = str
+
+
+def detect_anomalies(data_stream: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    """Inspect a project telemetry stream and report notable deviations.
+
+    Parameters
+    ----------
+    data_stream:
+        A list of dictionaries produced by schedulers, ERP exports or on-site
+        logs.  The function is resilient to missing keys and silently skips
+        malformed entries.
+
+    Returns
+    -------
+    list
+        Structured anomaly records with the following keys:
+
+        ``type``
+            Category of the anomaly (``risk``, ``schedule``, ``cost``,
+            ``safety`` or ``quality``).
+        ``severity``
+            One of ``low``, ``medium``, ``high`` or ``critical`` depending on
+            the magnitude of the finding.
+        ``message``
+            Human readable description suitable for dashboards.
+        ``timestamp``
+            Original timestamp if available.
+        ``context``
+            Machine readable fields that triggered the anomaly.
+    """
+
+    findings: List[Dict[str, Any]] = []
+
+    for entry in data_stream or []:
+        if not isinstance(entry, dict):
+            continue
+
+        timestamp = entry.get("timestamp")
+
+        def add_finding(anomaly_type: str, severity: Severity, message: str, *, context: Optional[Dict[str, Any]] = None) -> None:
+            findings.append(
+                {
+                    "type": anomaly_type,
+                    "severity": severity,
+                    "message": message,
+                    "timestamp": timestamp,
+                    "context": context or {},
+                }
+            )
+
+        _check_risk(entry, add_finding)
+        _check_schedule(entry, add_finding)
+        _check_cost(entry, add_finding)
+        _check_safety(entry, add_finding)
+        _check_quality(entry, add_finding)
+
+    # Sort by severity to keep the most pressing anomalies at the top of the
+    # dashboard.  The ordering is stable for tests which makes assertions
+    # deterministic.
+    severity_order = {"critical": 0, "high": 1, "medium": 2, "low": 3}
+    findings.sort(key=lambda finding: severity_order.get(finding["severity"], 99))
+    return findings
+
+
+def _to_float(value: Any) -> Optional[float]:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _contains_any(text: str, keywords: Iterable[str]) -> bool:
+    lowered = text.lower()
+    return any(keyword in lowered for keyword in keywords)
+
+
+def _check_risk(entry: Dict[str, Any], add_finding) -> None:
+    risk_score = _to_float(entry.get("risk_score"))
+    if risk_score is None:
+        return
+
+    risk_threshold = _to_float(entry.get("risk_threshold")) or 0.7
+    if risk_score <= risk_threshold:
+        return
+
+    severity: Severity
+    if risk_score >= 0.9:
+        severity = "critical"
+    elif risk_score >= (risk_threshold + 0.15):
+        severity = "high"
+    else:
+        severity = "medium"
+
+    add_finding(
+        "risk",
+        severity,
+        f"Risk score {risk_score:.2f} exceeds threshold {risk_threshold:.2f} for {entry.get('section', 'project segment')}",
+        context={
+            "risk_score": risk_score,
+            "risk_threshold": risk_threshold,
+            "drivers": entry.get("risk_drivers", []),
+        },
+    )
+
+
+def _check_schedule(entry: Dict[str, Any], add_finding) -> None:
+    progress = _to_float(entry.get("progress_percent"))
+    expected = _to_float(entry.get("expected_progress_percent"))
+    tolerance = _to_float(entry.get("variance_tolerance"))
+    tolerance = tolerance if tolerance is not None else 5.0
+
+    if progress is not None and expected is not None:
+        variance = expected - progress
+        if variance > tolerance:
+            severity: Severity = "high" if variance >= tolerance * 2 else "medium"
+            add_finding(
+                "schedule",
+                severity,
+                f"Progress trailing plan by {variance:.1f} percentage points",
+                context={
+                    "expected_progress_percent": expected,
+                    "actual_progress_percent": progress,
+                    "variance_percent": variance,
+                },
+            )
+
+    delay_days = _to_float(entry.get("schedule_delay_days")) or _to_float(entry.get("days_late"))
+    if delay_days and delay_days > 0:
+        severity = "critical" if delay_days >= 14 else ("high" if delay_days >= 7 else "medium")
+        add_finding(
+            "schedule",
+            severity,
+            f"Milestone late by {int(delay_days)} days",
+            context={
+                "milestone": entry.get("milestone"),
+                "delay_days": delay_days,
+            },
+        )
+
+
+def _check_cost(entry: Dict[str, Any], add_finding) -> None:
+    planned_cost = _to_float(entry.get("planned_cost"))
+    actual_cost = _to_float(entry.get("actual_cost"))
+    if planned_cost is None or actual_cost is None or planned_cost == 0:
+        return
+
+    deviation_pct = ((actual_cost - planned_cost) / planned_cost) * 100
+    tolerance_pct = _to_float(entry.get("cost_tolerance_pct")) or 5.0
+
+    if deviation_pct <= tolerance_pct:
+        return
+
+    severity: Severity = "high" if deviation_pct >= tolerance_pct * 2 else "medium"
+
+    add_finding(
+        "cost",
+        severity,
+        f"Cost overrun of {deviation_pct:.1f}% detected",
+        context={
+            "planned_cost": planned_cost,
+            "actual_cost": actual_cost,
+            "deviation_pct": deviation_pct,
+        },
+    )
+
+
+def _check_safety(entry: Dict[str, Any], add_finding) -> None:
+    incidents = entry.get("incidents") or entry.get("safety_incidents") or entry.get("incident_count")
+    if incidents:
+        try:
+            incident_count = int(incidents)
+        except (TypeError, ValueError):
+            incident_count = 0
+
+        if incident_count > 0:
+            severity: Severity
+            if incident_count >= 3 or _contains_any(entry.get("notes", ""), ["lost time", "hospitalisation", "hospitalization", "major"]):
+                severity = "critical"
+            elif incident_count == 2:
+                severity = "high"
+            else:
+                severity = "medium"
+
+            add_finding(
+                "safety",
+                severity,
+                f"Recorded {incident_count} safety incident(s)",
+                context={
+                    "incident_count": incident_count,
+                    "notes": entry.get("notes"),
+                },
+            )
+
+    if _contains_any(entry.get("notes", ""), ["near miss", "near-miss", "ppe non-compliance"]):
+        add_finding(
+            "safety",
+            "low",
+            "Near miss reported – schedule refresher training",
+            context={"notes": entry.get("notes")},
+        )
+
+
+def _check_quality(entry: Dict[str, Any], add_finding) -> None:
+    defects = entry.get("defects") or entry.get("punch_items")
+    if defects:
+        try:
+            defect_count = int(defects)
+        except (TypeError, ValueError):
+            defect_count = 0
+
+        if defect_count > 0:
+            severity: Severity = "high" if defect_count >= 5 else "medium"
+            add_finding(
+                "quality",
+                severity,
+                f"{defect_count} quality punch list item(s) logged",
+                context={"defects": defect_count, "location": entry.get("section")},
+            )
+
+    if _contains_any(entry.get("notes", ""), ["rework", "non-conformance", "failed inspection"]):
+        add_finding(
+            "quality",
+            "medium",
+            "Quality non-conformance requires follow-up",
+            context={"notes": entry.get("notes"), "inspection": entry.get("inspection")},
+        )

--- a/backend/services/compliance_monitor.py
+++ b/backend/services/compliance_monitor.py
@@ -1,1 +1,137 @@
-def check_compliance(document_text: str, rules: list): return []
+"""Compliance monitoring utilities for project documentation."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+
+@dataclass
+class NormalisedRule:
+    """Internal representation of a compliance rule."""
+
+    rule_id: str
+    description: str
+    severity: str
+    required_phrases: List[str]
+    forbidden_phrases: List[str]
+    recommendations: Optional[str] = None
+
+
+def check_compliance(document_text: str, rules: List[Any]) -> List[Dict[str, Any]]:
+    """Assess a document against governance rules.
+
+    Parameters
+    ----------
+    document_text:
+        Full text of the document being assessed.
+    rules:
+        A list of rule definitions.  Each rule can be a string (shorthand for a
+        required phrase) or a dictionary with the following optional keys:
+
+        ``id``
+            Identifier for traceability in the UI.
+        ``description``
+            Human readable text describing the requirement.
+        ``severity``
+            ``low`` | ``medium`` | ``high`` – defaults to ``medium``.
+        ``required_phrases``
+            Iterable of phrases that must be present in ``document_text``.
+        ``forbidden_phrases``
+            Iterable of phrases that should *not* appear.
+        ``recommendation``
+            Suggested remediation message.
+
+    Returns
+    -------
+    list
+        Each element contains ``rule_id``, ``status`` (``compliant``,
+        ``warning`` or ``violation``), ``severity`` and ``details`` providing
+        context for dashboards.
+    """
+
+    if not document_text:
+        document_text = ""
+
+    text_lower = document_text.lower()
+    findings: List[Dict[str, Any]] = []
+
+    for raw_rule in rules or []:
+        rule = _normalise_rule(raw_rule)
+        missing = _missing_phrases(text_lower, rule.required_phrases)
+        forbidden_hits = _present_phrases(text_lower, rule.forbidden_phrases)
+
+        if missing and forbidden_hits:
+            status = "violation"
+            details = (
+                f"Missing {', '.join(missing)} and detected forbidden phrases {', '.join(forbidden_hits)}"
+            )
+        elif missing:
+            status = "violation"
+            details = f"Missing required phrase(s): {', '.join(missing)}"
+        elif forbidden_hits:
+            status = "warning" if rule.severity == "low" else "violation"
+            details = f"Forbidden phrase(s) present: {', '.join(forbidden_hits)}"
+        else:
+            status = "compliant"
+            details = "Requirement satisfied"
+
+        finding: Dict[str, Any] = {
+            "rule_id": rule.rule_id,
+            "description": rule.description,
+            "status": status,
+            "severity": rule.severity,
+            "details": details,
+        }
+
+        if rule.recommendations and status != "compliant":
+            finding["recommendation"] = rule.recommendations
+
+        findings.append(finding)
+
+    return findings
+
+
+def _normalise_rule(raw_rule: Any) -> NormalisedRule:
+    if isinstance(raw_rule, str):
+        return NormalisedRule(
+            rule_id=raw_rule,
+            description=f"Document must mention '{raw_rule}'",
+            severity="medium",
+            required_phrases=[raw_rule],
+            forbidden_phrases=[],
+        )
+
+    if not isinstance(raw_rule, dict):
+        return NormalisedRule(
+            rule_id="unknown",
+            description="Unstructured rule",
+            severity="low",
+            required_phrases=[],
+            forbidden_phrases=[],
+        )
+
+    return NormalisedRule(
+        rule_id=str(raw_rule.get("id", raw_rule.get("rule_id", "rule"))),
+        description=str(raw_rule.get("description", "Unnamed requirement")),
+        severity=str(raw_rule.get("severity", "medium")),
+        required_phrases=list(_ensure_iterable(raw_rule.get("required_phrases", []))),
+        forbidden_phrases=list(_ensure_iterable(raw_rule.get("forbidden_phrases", []))),
+        recommendations=raw_rule.get("recommendation"),
+    )
+
+
+def _ensure_iterable(value: Any) -> Iterable[str]:
+    if isinstance(value, (list, tuple, set)):
+        return value
+    if value:
+        return [value]
+    return []
+
+
+def _missing_phrases(text_lower: str, phrases: Iterable[str]) -> List[str]:
+    return [phrase for phrase in phrases if phrase.lower() not in text_lower]
+
+
+def _present_phrases(text_lower: str, phrases: Iterable[str]) -> List[str]:
+    return [phrase for phrase in phrases if phrase.lower() in text_lower]

--- a/backend/services/meeting_summarizer.py
+++ b/backend/services/meeting_summarizer.py
@@ -1,1 +1,172 @@
-def summarize_transcript(transcript: str): return {'summary': '', 'decisions': [], 'issues': []}
+"""Generate structured meeting notes from raw transcripts."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Any, Dict, Iterable, List, Optional
+
+SENTENCE_SPLIT_RE = re.compile(r"(?<=[.!?])\s+|\n+")
+
+
+@dataclass
+class ExtractedItem:
+    description: str
+    owner: Optional[str] = None
+    due_date: Optional[str] = None
+    severity: Optional[str] = None
+
+    def as_dict(self) -> Dict[str, Any]:
+        payload = {"description": self.description}
+        if self.owner:
+            payload["owner"] = self.owner
+        if self.due_date:
+            payload["due_date"] = self.due_date
+        if self.severity:
+            payload["severity"] = self.severity
+        return payload
+
+
+def summarize_transcript(transcript: str) -> Dict[str, Any]:
+    """Convert a transcript into digestible summary artefacts."""
+
+    if not transcript or not transcript.strip():
+        return {
+            "summary": "",
+            "decisions": [],
+            "action_items": [],
+            "issues": [],
+        }
+
+    sentences = _tokenise(transcript)
+    decisions = _extract_items(sentences, {"decision", "decided", "approved", "approve"})
+    action_items = _extract_items(
+        sentences,
+        {"action", "follow up", "assign", "deliver", "send", "prepare"},
+        default_owner_keywords={"assigned to", "to "},
+    )
+    issues = _extract_items(
+        sentences,
+        {"issue", "risk", "concern", "blocker", "delay"},
+        severity_keywords={"critical": "high", "major": "high", "minor": "low"},
+    )
+
+    summary = _build_summary(sentences, decisions, issues, action_items)
+
+    return {
+        "summary": summary,
+        "decisions": [item.as_dict() for item in decisions],
+        "action_items": [item.as_dict() for item in action_items],
+        "issues": [item.as_dict() for item in issues],
+    }
+
+
+def _tokenise(transcript: str) -> List[str]:
+    statements = [segment.strip() for segment in SENTENCE_SPLIT_RE.split(transcript) if segment.strip()]
+    normalised: List[str] = []
+    for statement in statements:
+        cleaned = re.sub(r"^[A-Za-z ]{1,40}:\s*", "", statement)
+        if cleaned:
+            normalised.append(cleaned)
+    return normalised
+
+
+def _extract_items(
+    sentences: Iterable[str],
+    keywords: Iterable[str],
+    *,
+    default_owner_keywords: Optional[Iterable[str]] = None,
+    severity_keywords: Optional[Dict[str, str]] = None,
+) -> List[ExtractedItem]:
+    extracted: List[ExtractedItem] = []
+    keyword_list = [keyword.lower() for keyword in keywords]
+
+    for sentence in sentences:
+        lower_sentence = sentence.lower()
+        if not any(keyword in lower_sentence for keyword in keyword_list):
+            continue
+
+        owner = _extract_owner(sentence, default_owner_keywords)
+        due_date = _extract_due_date(sentence)
+        severity = _extract_severity(lower_sentence, severity_keywords)
+        extracted.append(
+            ExtractedItem(
+                description=_clean_description(sentence),
+                owner=owner,
+                due_date=due_date,
+                severity=severity,
+            )
+        )
+
+    return extracted
+
+
+def _extract_owner(sentence: str, keywords: Optional[Iterable[str]]) -> Optional[str]:
+    if not keywords:
+        return None
+
+    lower_sentence = sentence.lower()
+    for keyword in keywords:
+        keyword_lower = keyword.lower()
+        index = lower_sentence.find(keyword_lower)
+        if index == -1:
+            continue
+        tail = sentence[index + len(keyword_lower) :].strip()
+        match = re.match(r"([A-Z][a-z]+(?: [A-Z][a-z]+)*)", tail)
+        if match:
+            return match.group(1)
+    return None
+
+
+def _extract_due_date(sentence: str) -> Optional[str]:
+    match = re.search(
+        r"\bby ([A-Za-z]+ \d{1,2}|end of [A-Za-z]+|next week|(?:Q[1-4]|Monday|Tuesday|Wednesday|Thursday|Friday))",
+        sentence,
+        re.IGNORECASE,
+    )
+    if match:
+        return match.group(1)
+    match = re.search(r"\bby (\d{4}-\d{2}-\d{2})", sentence)
+    if match:
+        return match.group(1)
+    return None
+
+
+def _extract_severity(lower_sentence: str, severity_keywords: Optional[Dict[str, str]]) -> Optional[str]:
+    if not severity_keywords:
+        return None
+    for keyword, severity in severity_keywords.items():
+        if keyword in lower_sentence:
+            return severity
+    if "urgent" in lower_sentence or "immediate" in lower_sentence:
+        return "high"
+    return None
+
+
+def _clean_description(sentence: str) -> str:
+    sentence = sentence.strip()
+    sentence = re.sub(r"\b(decision|decided|action|issue)[:\s]", "", sentence, flags=re.IGNORECASE)
+    return sentence
+
+
+def _build_summary(
+    sentences: List[str],
+    decisions: List[ExtractedItem],
+    issues: List[ExtractedItem],
+    action_items: List[ExtractedItem],
+) -> str:
+    highlights: List[str] = []
+
+    if decisions:
+        highlights.append(f"Key decisions: {', '.join(item.description for item in decisions[:2])}")
+
+    if issues:
+        highlights.append(f"Outstanding risks: {', '.join(item.description for item in issues[:2])}")
+
+    if action_items:
+        highlights.append(f"Next actions: {', '.join(item.description for item in action_items[:2])}")
+
+    if not highlights:
+        highlights = sentences[:2]
+
+    return " ".join(highlights)

--- a/backend/tests/test_meeting_summarizer.py
+++ b/backend/tests/test_meeting_summarizer.py
@@ -1,0 +1,29 @@
+from backend.services.meeting_summarizer import summarize_transcript
+
+
+def test_summarize_transcript_produces_structured_minutes() -> None:
+    transcript = (
+        "Project Manager: Let's review the foundation progress. Concrete pour completed for zones A and B, "
+        "but zone C delayed by the rebar delivery.\n"
+        "Design Lead: Decision: Approve revised façade panels with bronze finish.\n"
+        "Operations Lead: Action assigned to Procurement to place the order by Friday.\n"
+        "Structural Engineer: Issue: Elevator core vendor still awaiting final drawings; this is becoming critical.\n"
+        "Project Manager: Action assigned to Sarah to deliver the updated drawings by Tuesday.\n"
+    )
+
+    summary = summarize_transcript(transcript)
+
+    assert "Key decisions" in summary["summary"]
+    assert any("façade panels" in decision["description"] for decision in summary["decisions"])
+    assert any(item.get("owner") == "Procurement" for item in summary["action_items"])
+    assert any(item.get("owner") == "Sarah" for item in summary["action_items"])
+    assert any(issue.get("severity") == "high" for issue in summary["issues"])
+
+
+def test_summarize_transcript_handles_empty_input() -> None:
+    assert summarize_transcript("") == {
+        "summary": "",
+        "decisions": [],
+        "action_items": [],
+        "issues": [],
+    }


### PR DESCRIPTION
## Summary
- implement rule-based telemetry anomaly detection and compliance checks for dashboards
- expose concrete analytics metrics through the /analytics/summary endpoint
- enhance the meeting summarizer to produce actionable notes and add unit coverage

## Testing
- pytest backend/tests/test_meeting_summarizer.py
- pytest backend/tests/test_services_smoke.py

------
https://chatgpt.com/codex/tasks/task_e_68de763c9418832a8e725922953e277f