### PR TITLE
Implement live connector health checks

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -5,3 +5,22 @@ FastAPI backend with Google Drive, RAG, Whisper STT, YOLO vision, and analytics.
 ## Run (local)
 pip install -r backend/requirements.txt
 uvicorn backend.main:app --reload --host 0.0.0.0 --port 8000
+
+## Connector configuration
+
+The following environment variables are consumed by the connector health
+endpoints and the new service clients:
+
+| Service | Required variables |
+| ------- | ------------------ |
+| Google Drive | `GOOGLE_SERVICE_ACCOUNT` (path to credentials) |
+| Oracle Aconex | `ACONEX_BASE_URL`, `ACONEX_API_KEY`, optional `ACONEX_HEALTH_PATH`, `ACONEX_TIMEOUT` |
+| Primavera P6 | `PRIMAVERA_BASE_URL`, `PRIMAVERA_USERNAME`, `PRIMAVERA_PASSWORD`, optional `PRIMAVERA_HEALTH_PATH`, `PRIMAVERA_TIMEOUT` |
+| BIM/IFC service | `BIM_BASE_URL`, `BIM_AUTH_TOKEN`, optional `BIM_HEALTH_PATH`, `BIM_TIMEOUT` |
+| Vision/YOLO service | `VISION_BASE_URL`, `VISION_API_KEY`, optional `VISION_HEALTH_PATH`, `VISION_TIMEOUT` |
+| OneDrive | `ONEDRIVE_HEALTH_URL`, optional `ONEDRIVE_ACCESS_TOKEN`, optional `CONNECTOR_HTTP_TIMEOUT` |
+| Power BI | `POWER_BI_HEALTH_URL`, optional `POWER_BI_API_KEY`, optional `CONNECTOR_HTTP_TIMEOUT` |
+| Microsoft Teams | `TEAMS_HEALTH_URL` and optional `TEAMS_API_TOKEN`, or `TEAMS_WEBHOOK_URL` for webhook-only setups |
+
+All health endpoints expect JSON responses. When the health URL returns plain
+text the raw response body is exposed under the ``details.raw`` key.

--- a/backend/api/connectors.py
+++ b/backend/api/connectors.py
@@ -1,5 +1,112 @@
+"""API surface for reporting connector health."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict
+
+import httpx
 from fastapi import APIRouter
+
+from backend.services import google_drive
+from backend.services.aconex import check_connection as aconex_status
+from backend.services.bim import check_connection as bim_status
+from backend.services.primavera import check_connection as primavera_status
+from backend.services.vision import check_connection as vision_status
+
 router = APIRouter()
+
+_DEFAULT_TIMEOUT = 5.0
+
+
+def _http_health_from_env(service: str, url_env: str, token_env: str | None = None) -> Dict[str, Any]:
+    url = os.getenv(url_env, "").strip()
+    if not url:
+        return {"service": service, "status": "unconfigured", "error": f"{url_env} is not set"}
+
+    headers = {"Accept": "application/json"}
+    if token_env:
+        token_value = os.getenv(token_env, "").strip()
+        if token_value:
+            headers["Authorization"] = f"Bearer {token_value}"
+
+    timeout = float(os.getenv("CONNECTOR_HTTP_TIMEOUT", _DEFAULT_TIMEOUT))
+    try:
+        response = httpx.get(url, headers=headers, timeout=timeout)
+        response.raise_for_status()
+    except httpx.HTTPError as exc:
+        return {"service": service, "status": "error", "error": f"{service} health check failed: {exc}"}
+
+    try:
+        payload = response.json()
+    except json.JSONDecodeError:
+        payload = {"raw": response.text}
+    return {"service": service, "status": "connected", "details": payload}
+
+
+def _google_drive_status() -> Dict[str, Any]:
+    credentials_available = google_drive.drive_credentials_available()
+    stubbed = google_drive.drive_stubbed()
+    error = google_drive.drive_service_error()
+    status = "connected"
+    if error:
+        status = "error"
+    elif stubbed or not credentials_available:
+        status = "stubbed"
+
+    payload: Dict[str, Any] = {
+        "service": "google_drive",
+        "status": status,
+        "details": {
+            "credentials_available": credentials_available,
+            "stubbed": stubbed,
+        },
+    }
+    if error:
+        payload["error"] = error
+    return payload
+
+
+def _onedrive_status() -> Dict[str, Any]:
+    return _http_health_from_env("onedrive", "ONEDRIVE_HEALTH_URL", "ONEDRIVE_ACCESS_TOKEN")
+
+
+def _power_bi_status() -> Dict[str, Any]:
+    return _http_health_from_env("power_bi", "POWER_BI_HEALTH_URL", "POWER_BI_API_KEY")
+
+
+def _teams_status() -> Dict[str, Any]:
+    health_url = os.getenv("TEAMS_HEALTH_URL", "").strip()
+    if health_url:
+        return _http_health_from_env("teams", "TEAMS_HEALTH_URL", "TEAMS_API_TOKEN")
+
+    webhook_url = os.getenv("TEAMS_WEBHOOK_URL", "").strip()
+    if webhook_url:
+        return {
+            "service": "teams",
+            "status": "configured",
+            "details": {"webhook_configured": True},
+        }
+    return {"service": "teams", "status": "unconfigured", "error": "TEAMS_WEBHOOK_URL is not set"}
+
+
+def _vision_status() -> Dict[str, Any]:
+    payload = vision_status()
+    payload = dict(payload)
+    payload["service"] = "photo"
+    return payload
+
+
 @router.get("/connectors/list")
-def list_connectors():
-    return {"p6":"Not connected","aconex":"Not connected","bim":"Not connected","whatsapp":"Not connected","teams":"Not connected"}
+def list_connectors() -> Dict[str, Dict[str, Any]]:
+    return {
+        "google_drive": _google_drive_status(),
+        "onedrive": _onedrive_status(),
+        "teams": _teams_status(),
+        "power_bi": _power_bi_status(),
+        "bim": bim_status(),
+        "p6": primavera_status(),
+        "aconex": aconex_status(),
+        "photo": _vision_status(),
+    }

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ from backend.api import (
     alerts,
     cache,
     chat,
+    connectors,
     drive,
     drive_diagnose,
     drive_scan,
@@ -36,6 +37,7 @@ def _include_router_if_available(module, tag: str) -> None:
 
 for module, tag in (
     (chat, "Chat"),
+    (connectors, "Connectors"),
     (project, "Intel"),
     (cache, "Cache"),
     (alerts, "Alerts"),

--- a/backend/services/aconex.py
+++ b/backend/services/aconex.py
@@ -1,8 +1,99 @@
+"""Integration helpers for working with Oracle Aconex."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
 from .intent_router import router
 
-def handle_aconex(message, context):
-    # TODO: replace with real aconex logic
-    return {"service": "aconex", "result": "Handled by aconex"} 
+_DEFAULT_TIMEOUT = 10.0
+
+
+class AconexError(RuntimeError):
+    """Raised when the Aconex service cannot be reached."""
+
+
+class AconexConfigurationError(ValueError):
+    """Raised when the Aconex client is missing mandatory configuration."""
+
+
+def _load_json(response: httpx.Response) -> Dict[str, Any]:
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return {"raw": response.text}
+
+
+class AconexClient:
+    """Small wrapper around the Aconex REST API."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        configured_url = base_url or os.getenv("ACONEX_BASE_URL", "").strip()
+        configured_key = api_key or os.getenv("ACONEX_API_KEY", "").strip()
+        if not configured_url:
+            raise AconexConfigurationError("ACONEX_BASE_URL is not configured")
+        if not configured_key:
+            raise AconexConfigurationError("ACONEX_API_KEY is not configured")
+
+        self._base_url = configured_url.rstrip("/")
+        self._api_key = configured_key
+        self._timeout = timeout or float(os.getenv("ACONEX_TIMEOUT", _DEFAULT_TIMEOUT))
+        self._health_path = os.getenv("ACONEX_HEALTH_PATH", "/health").lstrip("/")
+
+    def ping(self) -> Dict[str, Any]:
+        """Perform a lightweight health-check call against Aconex."""
+
+        url = f"{self._base_url}/{self._health_path}" if self._health_path else self._base_url
+        headers = {"Authorization": f"Bearer {self._api_key}", "Accept": "application/json"}
+        try:
+            response = httpx.get(url, headers=headers, timeout=self._timeout)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise AconexError(f"Aconex health check failed: {exc}") from exc
+        return _load_json(response)
+
+
+def check_connection(client: Optional[AconexClient] = None) -> Dict[str, Any]:
+    """Return a structured payload describing the current connection status."""
+
+    try:
+        client = client or AconexClient()
+    except AconexConfigurationError as exc:
+        return {"service": "aconex", "status": "unconfigured", "error": str(exc)}
+
+    try:
+        payload = client.ping()
+    except AconexError as exc:
+        return {"service": "aconex", "status": "error", "error": str(exc)}
+    return {"service": "aconex", "status": "connected", "details": payload}
+
+
+def handle_aconex(message: Any, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    """Handle intents destined for the Aconex connector."""
+
+    try:
+        client = AconexClient()
+        health = client.ping()
+    except (AconexConfigurationError, AconexError) as exc:
+        return {"service": "aconex", "status": "error", "error": str(exc)}
+
+    summary = {
+        "input": message,
+        "context": context or {},
+        "health": health,
+    }
+    return {"service": "aconex", "status": "connected", "result": summary}
+
 
 # Register service on import
-router.register("aconex", ['\\baconex\\b'], handle_aconex)
+router.register("aconex", ["\\baconex\\b"], handle_aconex)

--- a/backend/services/bim.py
+++ b/backend/services/bim.py
@@ -1,8 +1,93 @@
+"""Utilities for working with BIM/IFC services."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
 from .intent_router import router
 
-def handle_bim(message, context):
-    # TODO: replace with real bim logic
-    return {"service": "bim", "result": "Handled by bim"} 
+_DEFAULT_TIMEOUT = 10.0
+
+
+class BIMError(RuntimeError):
+    """Raised when the BIM service cannot be contacted."""
+
+
+class BIMConfigurationError(ValueError):
+    """Raised when the BIM client is misconfigured."""
+
+
+def _load_json(response: httpx.Response) -> Dict[str, Any]:
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return {"raw": response.text}
+
+
+class BIMClient:
+    """Very small helper for invoking a BIM/IFC processing service."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        token: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        configured_url = base_url or os.getenv("BIM_BASE_URL", "").strip()
+        configured_token = token or os.getenv("BIM_AUTH_TOKEN", "").strip()
+        if not configured_url:
+            raise BIMConfigurationError("BIM_BASE_URL is not configured")
+        if not configured_token:
+            raise BIMConfigurationError("BIM_AUTH_TOKEN is not configured")
+
+        self._base_url = configured_url.rstrip("/")
+        self._token = configured_token
+        self._timeout = timeout or float(os.getenv("BIM_TIMEOUT", _DEFAULT_TIMEOUT))
+        self._health_path = os.getenv("BIM_HEALTH_PATH", "/health").lstrip("/")
+
+    def ping(self) -> Dict[str, Any]:
+        url = f"{self._base_url}/{self._health_path}" if self._health_path else self._base_url
+        headers = {"Authorization": f"Bearer {self._token}", "Accept": "application/json"}
+        try:
+            response = httpx.get(url, headers=headers, timeout=self._timeout)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise BIMError(f"BIM health check failed: {exc}") from exc
+        return _load_json(response)
+
+
+def check_connection(client: Optional[BIMClient] = None) -> Dict[str, Any]:
+    try:
+        client = client or BIMClient()
+    except BIMConfigurationError as exc:
+        return {"service": "bim", "status": "unconfigured", "error": str(exc)}
+
+    try:
+        payload = client.ping()
+    except BIMError as exc:
+        return {"service": "bim", "status": "error", "error": str(exc)}
+    return {"service": "bim", "status": "connected", "details": payload}
+
+
+def handle_bim(message: Any, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    try:
+        client = BIMClient()
+        health = client.ping()
+    except (BIMConfigurationError, BIMError) as exc:
+        return {"service": "bim", "status": "error", "error": str(exc)}
+
+    summary = {
+        "input": message,
+        "context": context or {},
+        "health": health,
+    }
+    return {"service": "bim", "status": "connected", "result": summary}
+
 
 # Register service on import
 router.register("bim", ['\\bbim\\b', '\\bifc\\b'], handle_bim)

--- a/backend/services/primavera.py
+++ b/backend/services/primavera.py
@@ -1,8 +1,94 @@
+"""Primavera P6 service integration helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
 from .intent_router import router
 
-def handle_primavera(message, context):
-    # TODO: replace with real primavera logic
-    return {"service": "primavera", "result": "Handled by primavera"} 
+_DEFAULT_TIMEOUT = 10.0
+
+
+class PrimaveraError(RuntimeError):
+    """Raised when Primavera cannot be contacted."""
+
+
+class PrimaveraConfigurationError(ValueError):
+    """Raised when the Primavera client is missing configuration."""
+
+
+def _load_json(response: httpx.Response) -> Dict[str, Any]:
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return {"raw": response.text}
+
+
+class PrimaveraClient:
+    """Very small HTTP client for Primavera P6 endpoints."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        username: Optional[str] = None,
+        password: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        configured_url = base_url or os.getenv("PRIMAVERA_BASE_URL", "").strip()
+        configured_user = username or os.getenv("PRIMAVERA_USERNAME", "").strip()
+        configured_password = password or os.getenv("PRIMAVERA_PASSWORD", "").strip()
+        if not configured_url:
+            raise PrimaveraConfigurationError("PRIMAVERA_BASE_URL is not configured")
+        if not configured_user or not configured_password:
+            raise PrimaveraConfigurationError("PRIMAVERA_USERNAME/PRIMAVERA_PASSWORD must be configured")
+
+        self._base_url = configured_url.rstrip("/")
+        self._auth = (configured_user, configured_password)
+        self._timeout = timeout or float(os.getenv("PRIMAVERA_TIMEOUT", _DEFAULT_TIMEOUT))
+        self._health_path = os.getenv("PRIMAVERA_HEALTH_PATH", "/health").lstrip("/")
+
+    def ping(self) -> Dict[str, Any]:
+        url = f"{self._base_url}/{self._health_path}" if self._health_path else self._base_url
+        try:
+            response = httpx.get(url, auth=self._auth, timeout=self._timeout)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise PrimaveraError(f"Primavera health check failed: {exc}") from exc
+        return _load_json(response)
+
+
+def check_connection(client: Optional[PrimaveraClient] = None) -> Dict[str, Any]:
+    try:
+        client = client or PrimaveraClient()
+    except PrimaveraConfigurationError as exc:
+        return {"service": "p6", "status": "unconfigured", "error": str(exc)}
+
+    try:
+        payload = client.ping()
+    except PrimaveraError as exc:
+        return {"service": "p6", "status": "error", "error": str(exc)}
+    return {"service": "p6", "status": "connected", "details": payload}
+
+
+def handle_primavera(message: Any, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    try:
+        client = PrimaveraClient()
+        health = client.ping()
+    except (PrimaveraConfigurationError, PrimaveraError) as exc:
+        return {"service": "primavera", "status": "error", "error": str(exc)}
+
+    summary = {
+        "input": message,
+        "context": context or {},
+        "health": health,
+    }
+    return {"service": "primavera", "status": "connected", "result": summary}
+
 
 # Register service on import
 router.register("primavera", ['\\bprimavera\\b', '\\.xer\\b'], handle_primavera)

--- a/backend/services/vision.py
+++ b/backend/services/vision.py
@@ -1,8 +1,93 @@
+"""YOLO/photo tooling integration helpers."""
+
+from __future__ import annotations
+
+import json
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
 from .intent_router import router
 
-def handle_vision(message, context):
-    # TODO: replace with real vision logic
-    return {"service": "vision", "result": "Handled by vision"} 
+_DEFAULT_TIMEOUT = 10.0
+
+
+class VisionError(RuntimeError):
+    """Raised when the vision service encounters a problem."""
+
+
+class VisionConfigurationError(ValueError):
+    """Raised when the vision client is misconfigured."""
+
+
+def _load_json(response: httpx.Response) -> Dict[str, Any]:
+    try:
+        return response.json()
+    except json.JSONDecodeError:
+        return {"raw": response.text}
+
+
+class VisionClient:
+    """Minimal HTTP client for a YOLO/vision microservice."""
+
+    def __init__(
+        self,
+        *,
+        base_url: Optional[str] = None,
+        api_key: Optional[str] = None,
+        timeout: Optional[float] = None,
+    ) -> None:
+        configured_url = base_url or os.getenv("VISION_BASE_URL", "").strip()
+        configured_key = api_key or os.getenv("VISION_API_KEY", "").strip()
+        if not configured_url:
+            raise VisionConfigurationError("VISION_BASE_URL is not configured")
+        if not configured_key:
+            raise VisionConfigurationError("VISION_API_KEY is not configured")
+
+        self._base_url = configured_url.rstrip("/")
+        self._api_key = configured_key
+        self._timeout = timeout or float(os.getenv("VISION_TIMEOUT", _DEFAULT_TIMEOUT))
+        self._health_path = os.getenv("VISION_HEALTH_PATH", "/healthz").lstrip("/")
+
+    def ping(self) -> Dict[str, Any]:
+        url = f"{self._base_url}/{self._health_path}" if self._health_path else self._base_url
+        headers = {"Authorization": f"Bearer {self._api_key}", "Accept": "application/json"}
+        try:
+            response = httpx.get(url, headers=headers, timeout=self._timeout)
+            response.raise_for_status()
+        except httpx.HTTPError as exc:
+            raise VisionError(f"Vision health check failed: {exc}") from exc
+        return _load_json(response)
+
+
+def check_connection(client: Optional[VisionClient] = None) -> Dict[str, Any]:
+    try:
+        client = client or VisionClient()
+    except VisionConfigurationError as exc:
+        return {"service": "vision", "status": "unconfigured", "error": str(exc)}
+
+    try:
+        payload = client.ping()
+    except VisionError as exc:
+        return {"service": "vision", "status": "error", "error": str(exc)}
+    return {"service": "vision", "status": "connected", "details": payload}
+
+
+def handle_vision(message: Any, context: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+    try:
+        client = VisionClient()
+        health = client.ping()
+    except (VisionConfigurationError, VisionError) as exc:
+        return {"service": "vision", "status": "error", "error": str(exc)}
+
+    summary = {
+        "input": message,
+        "context": context or {},
+        "health": health,
+    }
+    return {"service": "vision", "status": "connected", "result": summary}
+
 
 # Register service on import
 router.register("vision", ['\\byolo\\b', '\\bphoto\\b', '\\bimage\\b'], handle_vision)

--- a/backend/tests/test_connector_services.py
+++ b/backend/tests/test_connector_services.py
@@ -1,0 +1,176 @@
+"""Tests covering connector service integrations and API status reporting."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict
+
+import httpx
+import pytest
+
+from backend.api import connectors
+from backend.services import aconex, bim, primavera, vision
+
+
+def _response(url: str, *, status_code: int = 200, json_body: Dict[str, Any] | None = None) -> httpx.Response:
+    request = httpx.Request("GET", url)
+    if json_body is None:
+        content = b"{}"
+    else:
+        content = json.dumps(json_body).encode()
+    return httpx.Response(status_code=status_code, request=request, content=content)
+
+
+def test_aconex_check_connection_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACONEX_BASE_URL", "https://aconex.test")
+    monkeypatch.setenv("ACONEX_API_KEY", "secret")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float) -> httpx.Response:
+        assert url == "https://aconex.test/health"
+        assert headers["Authorization"].startswith("Bearer ")
+        return _response(url, json_body={"status": "ok"})
+
+    monkeypatch.setattr(aconex.httpx, "get", fake_get)
+    status = aconex.check_connection()
+    assert status["status"] == "connected"
+    assert status["details"]["status"] == "ok"
+
+
+def test_aconex_check_connection_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ACONEX_BASE_URL", "https://aconex.test")
+    monkeypatch.setenv("ACONEX_API_KEY", "secret")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float) -> httpx.Response:
+        raise httpx.ConnectError("boom", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(aconex.httpx, "get", fake_get)
+    status = aconex.check_connection()
+    assert status["status"] == "error"
+    assert "boom" in status["error"]
+
+
+def test_primavera_check_connection_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIMAVERA_BASE_URL", "https://p6.test")
+    monkeypatch.setenv("PRIMAVERA_USERNAME", "user")
+    monkeypatch.setenv("PRIMAVERA_PASSWORD", "pass")
+
+    def fake_get(url: str, *, auth: Any, timeout: float) -> httpx.Response:
+        assert url == "https://p6.test/health"
+        assert auth == ("user", "pass")
+        return _response(url, json_body={"status": "ok"})
+
+    monkeypatch.setattr(primavera.httpx, "get", fake_get)
+    status = primavera.check_connection()
+    assert status["status"] == "connected"
+
+
+def test_primavera_check_connection_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PRIMAVERA_BASE_URL", "https://p6.test")
+    monkeypatch.setenv("PRIMAVERA_USERNAME", "user")
+    monkeypatch.setenv("PRIMAVERA_PASSWORD", "pass")
+
+    def fake_get(url: str, *, auth: Any, timeout: float) -> httpx.Response:
+        raise httpx.HTTPStatusError("bad", request=httpx.Request("GET", url), response=_response(url, status_code=503))
+
+    monkeypatch.setattr(primavera.httpx, "get", fake_get)
+    status = primavera.check_connection()
+    assert status["status"] == "error"
+
+
+def test_bim_check_connection_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIM_BASE_URL", "https://bim.test")
+    monkeypatch.setenv("BIM_AUTH_TOKEN", "token")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float) -> httpx.Response:
+        assert headers["Authorization"].startswith("Bearer ")
+        return _response(url, json_body={"status": "ok"})
+
+    monkeypatch.setattr(bim.httpx, "get", fake_get)
+    status = bim.check_connection()
+    assert status["status"] == "connected"
+
+
+def test_bim_check_connection_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("BIM_BASE_URL", "https://bim.test")
+    monkeypatch.setenv("BIM_AUTH_TOKEN", "token")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float) -> httpx.Response:
+        raise httpx.ConnectTimeout("timeout", request=httpx.Request("GET", url))
+
+    monkeypatch.setattr(bim.httpx, "get", fake_get)
+    status = bim.check_connection()
+    assert status["status"] == "error"
+
+
+def test_vision_check_connection_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VISION_BASE_URL", "https://vision.test")
+    monkeypatch.setenv("VISION_API_KEY", "token")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float) -> httpx.Response:
+        assert headers["Authorization"].startswith("Bearer ")
+        return _response(url, json_body={"status": "ok"})
+
+    monkeypatch.setattr(vision.httpx, "get", fake_get)
+    status = vision.check_connection()
+    assert status["status"] == "connected"
+
+
+def test_vision_check_connection_failure(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("VISION_BASE_URL", "https://vision.test")
+    monkeypatch.setenv("VISION_API_KEY", "token")
+
+    def fake_get(url: str, *, headers: Dict[str, str], timeout: float) -> httpx.Response:
+        raise httpx.HTTPStatusError("bad", request=httpx.Request("GET", url), response=_response(url, status_code=500))
+
+    monkeypatch.setattr(vision.httpx, "get", fake_get)
+    status = vision.check_connection()
+    assert status["status"] == "error"
+
+
+def test_connectors_list_success(client: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ONEDRIVE_HEALTH_URL", "https://onedrive.test/health")
+    monkeypatch.setenv("POWER_BI_HEALTH_URL", "https://powerbi.test/health")
+    monkeypatch.setenv("TEAMS_HEALTH_URL", "https://teams.test/health")
+
+    def fake_get(url: str, **_: Any) -> httpx.Response:  # type: ignore[override]
+        return _response(url, json_body={"status": "ok"})
+
+    monkeypatch.setattr(connectors.httpx, "get", fake_get)
+    monkeypatch.setattr(connectors.google_drive, "drive_credentials_available", lambda: True)
+    monkeypatch.setattr(connectors.google_drive, "drive_stubbed", lambda: False)
+    monkeypatch.setattr(connectors.google_drive, "drive_service_error", lambda: None)
+    monkeypatch.setattr("backend.api.connectors.bim_status", lambda: {"service": "bim", "status": "connected"})
+    monkeypatch.setattr("backend.api.connectors.primavera_status", lambda: {"service": "p6", "status": "connected"})
+    monkeypatch.setattr("backend.api.connectors.aconex_status", lambda: {"service": "aconex", "status": "connected"})
+    monkeypatch.setattr("backend.api.connectors.vision_status", lambda: {"service": "vision", "status": "connected"})
+
+    response = client.get("/api/connectors/list")
+    data = response.json()
+    assert data["google_drive"]["status"] == "connected"
+    assert data["onedrive"]["status"] == "connected"
+    assert data["teams"]["status"] == "connected"
+    assert data["power_bi"]["status"] == "connected"
+    assert data["photo"]["service"] == "photo"
+
+
+def test_connectors_list_failure(client: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ONEDRIVE_HEALTH_URL", raising=False)
+    monkeypatch.delenv("POWER_BI_HEALTH_URL", raising=False)
+    monkeypatch.delenv("TEAMS_HEALTH_URL", raising=False)
+    monkeypatch.delenv("TEAMS_WEBHOOK_URL", raising=False)
+
+    monkeypatch.setattr(connectors.google_drive, "drive_credentials_available", lambda: False)
+    monkeypatch.setattr(connectors.google_drive, "drive_stubbed", lambda: True)
+    monkeypatch.setattr(connectors.google_drive, "drive_service_error", lambda: "missing credentials")
+    monkeypatch.setattr("backend.api.connectors.bim_status", lambda: {"service": "bim", "status": "error"})
+    monkeypatch.setattr("backend.api.connectors.primavera_status", lambda: {"service": "p6", "status": "error"})
+    monkeypatch.setattr("backend.api.connectors.aconex_status", lambda: {"service": "aconex", "status": "error"})
+    monkeypatch.setattr("backend.api.connectors.vision_status", lambda: {"service": "vision", "status": "error"})
+
+    response = client.get("/api/connectors/list")
+    data = response.json()
+    assert data["google_drive"]["status"] == "error"
+    assert data["onedrive"]["status"] == "unconfigured"
+    assert data["teams"]["status"] == "unconfigured"
+    assert data["power_bi"]["status"] == "unconfigured"
+    assert data["photo"]["status"] == "error"


### PR DESCRIPTION
## Summary
- replace the Aconex, Primavera, BIM, and vision stubs with HTTP clients driven by environment configuration
- update the /api/connectors/list endpoint to surface live health checks from Google Drive, Microsoft tooling, and the new service clients
- document connector environment variables and add automated tests for success/failure paths

## Testing
- pytest backend/tests/test_connector_services.py

------
https://chatgpt.com/codex/tasks/task_e_68de763da6f4832aad35a25f18c434eb