### PR TITLE
Serve frontend bundle through FastAPI root handler

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -27,9 +27,9 @@ RUN pip install --no-cache-dir -r /app/backend/requirements.txt \
     gunicorn==21.2.0
 
 COPY backend /app/backend
-COPY frontend/public /app/frontend/public
 RUN mkdir -p /app/uploads /app/images /app/storage
 COPY --from=frontend-build /frontend/dist /app/frontend_dist
+COPY --from=frontend-build /frontend/public /app/frontend/public
 
 EXPOSE 8000
 


### PR DESCRIPTION
## Summary
- serve the built demo index page from the FastAPI root endpoint and mount the public assets directory for static files
- fall back gracefully when frontend assets are missing so the API stays responsive
- copy the frontend build output and static assets into the backend Docker image for Render deployments

## Testing
- pytest *(fails: drive stubbed endpoints return 404 in current configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68de8123e010832aa1e363ce4735c7c3