### PR TITLE
Add httpx dependency for backend connectors

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,6 +11,7 @@ ezdxf==1.2.0
 spacy==3.7.5
 en-core-web-sm @ https://github.com/explosion/spacy-models/releases/download/en_core_web_sm-3.7.1/en_core_web_sm-3.7.1-py3-none-any.whl
 requests==2.32.3
+httpx
 aiofiles==24.1.0
 python-multipart==0.0.9
 openpyxl==3.1.5


### PR DESCRIPTION
## Summary
- add httpx to the backend requirements so connector modules have their dependency declared

## Testing
- pytest backend/tests/test_connector_services.py

------
https://chatgpt.com/codex/tasks/task_e_68de8515f59c832aa8ef14da248350ba