### PR TITLE
Fix drive diagnose stubbed endpoint response

### DIFF
--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -5,9 +5,12 @@ from fastapi import APIRouter
 router = APIRouter()
 
 
-@router.get("/drive/diagnostics")
-def drive_diagnostics() -> dict[str, str]:
+@router.get("/drive/diagnose")
+def drive_diagnose() -> dict[str, str]:
     """Return a stubbed response representing drive diagnostics."""
 
-    return {"status": "ok", "detail": "Drive diagnostics not implemented in tests"}
+    return {
+        "status": "error",
+        "detail": "Drive diagnostics is not available in tests",
+    }
 


### PR DESCRIPTION
## Summary
- register the drive diagnose stub at the /drive/diagnose route to match tests
- return the expected error payload so the stub communicates diagnostics are unavailable

## Testing
- `pytest backend/tests/test_drive_stubbed_endpoints.py::test_drive_diagnose_reports_error_when_stubbed`


------
https://chatgpt.com/codex/tasks/task_e_68de858b091c832a90259776cfaebea5