### PR TITLE
Enhance drive scan stub metadata

### DIFF
--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -5,9 +5,22 @@ from fastapi import APIRouter
 router = APIRouter()
 
 
-@router.get("/drive/diagnostics")
-def drive_diagnostics() -> dict[str, str]:
+_STUBBED_DIAGNOSE_RESPONSE: dict[str, str] = {
+    "status": "error",
+    "detail": "Drive diagnostics are not available in the stubbed environment.",
+}
+
+
+@router.get("/drive/diagnose")
+def drive_diagnose() -> dict[str, str]:
     """Return a stubbed response representing drive diagnostics."""
 
-    return {"status": "ok", "detail": "Drive diagnostics not implemented in tests"}
+    return _STUBBED_DIAGNOSE_RESPONSE
+
+
+@router.get("/drive/diagnostics")
+def drive_diagnostics() -> dict[str, str]:
+    """Backward-compatible alias for legacy clients."""
+
+    return _STUBBED_DIAGNOSE_RESPONSE
 

--- a/backend/api/drive_scan.py
+++ b/backend/api/drive_scan.py
@@ -1,8 +1,67 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
+from typing import List
+
 from fastapi import APIRouter
+from pydantic import BaseModel, Field
 
 router = APIRouter()
+
+
+class DriveScanProject(BaseModel):
+    """Represents a single project discovered during a drive scan."""
+
+    name: str = Field(..., description="Display name of the project folder")
+    path: str = Field(..., description="Absolute path to the project folder on disk")
+    last_modified: datetime = Field(
+        ..., description="Timestamp representing the most recent modification time"
+    )
+    source: str = Field(
+        "stubbed", description="Identifier for the provider that surfaced the project"
+    )
+
+
+class DriveScanResponse(BaseModel):
+    """Response schema returned when scanning the drive for project folders."""
+
+    status: str = Field(
+        "stubbed", description="Drive scan status indicating no real scan was performed"
+    )
+    detail: str = Field(
+        "Drive scanning is currently stubbed for development and tests.",
+        description="Additional information about the stubbed response",
+    )
+    projects: List[DriveScanProject] = Field(
+        default_factory=list,
+        description="Collection of project folders discovered on the drive",
+    )
+
+
+_STUBBED_PROJECTS: list[DriveScanProject] = [
+    DriveScanProject(
+        name="Gateway Villas",
+        path="/Volumes/Diriyah/Projects/Gateway Villas",
+        last_modified=datetime(2024, 1, 15, 9, 30, tzinfo=timezone.utc),
+    ),
+    DriveScanProject(
+        name="Downtown Towers",
+        path="/Volumes/Diriyah/Projects/Downtown Towers",
+        last_modified=datetime(2024, 3, 8, 17, 5, tzinfo=timezone.utc),
+    ),
+    DriveScanProject(
+        name="Cultural District",
+        path="/Volumes/Diriyah/Projects/Cultural District",
+        last_modified=datetime(2023, 11, 21, 13, 42, tzinfo=timezone.utc),
+    ),
+]
+
+
+@router.get("/projects/scan-drive")
+def scan_drive_for_projects() -> DriveScanResponse:
+    """Return a deterministic stubbed list of project folders."""
+
+    return DriveScanResponse(projects=_STUBBED_PROJECTS)
 
 
 @router.get("/drive/scan/status")
@@ -10,4 +69,3 @@ def drive_scan_status() -> dict[str, str]:
     """Return a stubbed response representing drive scanning state."""
 
     return {"status": "idle", "detail": "Drive scanning is not available in tests"}
-

--- a/backend/tests/test_drive_stubbed_endpoints.py
+++ b/backend/tests/test_drive_stubbed_endpoints.py
@@ -15,6 +15,22 @@ def test_drive_scan_returns_stubbed_projects() -> None:
     assert payload["projects"], "expected stubbed projects to be returned"
 
 
+def test_drive_scan_projects_include_debug_metadata() -> None:
+    with TestClient(app) as client:
+        response = client.get("/api/projects/scan-drive")
+        assert response.status_code == 200
+        payload = response.json()
+
+    assert payload.get("status") == "stubbed"
+    assert payload.get("detail")
+
+    for project in payload.get("projects", []):
+        assert isinstance(project["name"], str) and project["name"], "missing name"
+        assert isinstance(project["path"], str) and project["path"], "missing path"
+        assert "last_modified" in project and project["last_modified"], "missing last_modified"
+        assert project.get("source") == "stubbed"
+
+
 def test_drive_diagnose_reports_error_when_stubbed() -> None:
     with TestClient(app) as client:
         response = client.get("/api/drive/diagnose")

--- a/frontend/src/components/ProjectDropdown.jsx
+++ b/frontend/src/components/ProjectDropdown.jsx
@@ -3,6 +3,7 @@ import React, { useEffect, useState } from "react";
 const ProjectDropdown = ({ onSelect }) => {
   const [options, setOptions] = useState([]);
   const [error, setError] = useState("");
+  const [selectedIndex, setSelectedIndex] = useState(-1);
 
   useEffect(() => {
     const load = async () => {
@@ -10,7 +11,32 @@ const ProjectDropdown = ({ onSelect }) => {
         const res = await fetch("/api/projects/scan-drive");
         if (!res.ok) throw new Error(`Scan failed (${res.status})`);
         const data = await res.json();
-        setOptions(data.projects || []);
+        const projects = Array.isArray(data.projects) ? data.projects : [];
+        const normalized = projects.map((project, index) => {
+          if (typeof project === "string") {
+            return {
+              value: project,
+              label: project,
+              path: "",
+              lastModified: "",
+              source: "stubbed",
+            };
+          }
+
+          const label = project.name || project.path || `Project ${index + 1}`;
+          const lastModified =
+            project.last_modified || project.lastModified || "";
+
+          return {
+            value: project.name || label,
+            label,
+            path: project.path || "",
+            lastModified,
+            source: project.source || "stubbed",
+          };
+        });
+        setOptions(normalized);
+        setSelectedIndex(-1);
       } catch (e) {
         console.error("Failed to scan drive", e);
         setError("Unable to scan drive for project folders.");
@@ -21,11 +47,35 @@ const ProjectDropdown = ({ onSelect }) => {
 
   return (
     <div className="project-dropdown">
-      <select onChange={(e) => onSelect?.(e.target.value)} defaultValue="">
+      <select
+        onChange={(e) => {
+          const index = e.target.selectedIndex - 1;
+          setSelectedIndex(index);
+          const option = options[index];
+          onSelect?.(option ? option.value : "");
+        }}
+        value={selectedIndex >= 0 ? options[selectedIndex]?.value : ""}
+      >
         <option value="" disabled>Select a Drive project…</option>
-        {options.map((name) => (<option key={name} value={name}>{name}</option>))}
+        {options.map((option) => (
+          <option key={option.value} value={option.value} title={option.path}>
+            {option.label}
+          </option>
+        ))}
       </select>
       {error && <p className="project-dropdown-error">{error}</p>}
+      {!error && selectedIndex >= 0 && options[selectedIndex] && (
+        <div className="project-dropdown-debug">
+          <p><strong>Path:</strong> {options[selectedIndex].path || "Unknown"}</p>
+          {options[selectedIndex].lastModified && (
+            <p>
+              <strong>Last Modified:</strong>{" "}
+              {new Date(options[selectedIndex].lastModified).toLocaleString()}
+            </p>
+          )}
+          <p><strong>Source:</strong> {options[selectedIndex].source}</p>
+        </div>
+      )}
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add a stubbed `/projects/scan-drive` endpoint returning deterministic project metadata for debugging
- keep the existing drive scan status stub for compatibility
- expose the stubbed drive diagnostics response at `/drive/diagnose` and surface metadata in the React dropdown

## Testing
- pytest backend/tests/test_drive_stubbed_endpoints.py

------
https://chatgpt.com/codex/tasks/task_e_68de858aee0c832a928735ad904ef83f