### PR TITLE
Handle chat requests without active project context

### DIFF
--- a/backend/api/chat.py
+++ b/backend/api/chat.py
@@ -14,8 +14,13 @@ intent_router = IntentRouter()
 async def chat(message: str = Form(...)) -> dict[str, Any]:
     """Respond to chat messages while respecting the active project context."""
 
-    active = get_active_project() or {}
-    if not isinstance(active, Mapping):
+    active_project = get_active_project()
+
+    if isinstance(active_project, Mapping):
+        active: Mapping[str, Any] = active_project
+    elif isinstance(active_project, str):
+        active = {"id": active_project}
+    else:
         active = {}
 
     project_id = active.get("id")

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -10,13 +10,17 @@ _active_project: MutableMapping[str, Any] | None = None
 def _normalize_project(project: Any) -> MutableMapping[str, Any]:
     """Normalize different project representations into a mutable mapping."""
 
-    if project is None:
-        return {}
-
     if isinstance(project, Mapping):
-        return dict(project)
+        normalized: MutableMapping[str, Any] = dict(project)
+    elif project is None:
+        normalized = {}
+    else:
+        normalized = {"id": project}
 
-    return {"id": project}
+    normalized.setdefault("id", None)
+    normalized.setdefault("collection", None)
+
+    return normalized
 
 
 def set_active_project(
@@ -40,8 +44,6 @@ def set_active_project(
 
     if collection is not None:
         normalized["collection"] = collection
-    elif "collection" not in normalized:
-        normalized["collection"] = None
 
     _active_project = normalized
 
@@ -50,6 +52,6 @@ def get_active_project() -> MutableMapping[str, Any]:
     """Return information about the active project as a mapping."""
 
     if _active_project is None:
-        return {}
+        return _normalize_project(None)
 
     return _normalize_project(_active_project)

--- a/backend/tests/test_chat.py
+++ b/backend/tests/test_chat.py
@@ -47,6 +47,7 @@ def test_chat_without_active_project(client: TestClient) -> None:
     assert payload["project_id"] is None
     assert payload["context_docs"] == []
     assert payload["intent"]["project_id"] is None
+    assert payload["response"].endswith("none")
 
 
 def test_chat_with_active_project_collection(client: TestClient) -> None:


### PR DESCRIPTION
## Summary
- normalize active project storage to always expose id and collection fields
- guard the chat endpoint against non-mapping active project values when routing intents
- extend chat endpoint tests to confirm successful responses with no active project configured

## Testing
- pytest backend/tests/test_chat.py

------
https://chatgpt.com/codex/tasks/task_e_68de86cfb854832a8a091b7ed295f279