### PR TITLE
Implement Slack approval workflow and router layout

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+  pull_request:
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pytest
+        run: pytest
+
+  helm-lint-and-package:
+    runs-on: ubuntu-latest
+    needs: build-and-test
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+      - name: Set up Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: v3.14.4
+      - name: Helm lint
+        run: helm lint helm/diriyah-brain-ai
+      - name: Helm template
+        run: helm template test-release helm/diriyah-brain-ai
+
+  request-prod-approval:
+    needs: [build-and-test, helm-lint-and-package]
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    steps:
+      - name: Post Slack Approval Message
+        env:
+          CHANNEL: ${{ secrets.SLACK_APPROVAL_CHANNEL }}
+          TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+        run: |
+          COMMIT_SHA=${GITHUB_SHA}
+          curl -X POST -H "Authorization: Bearer $TOKEN" -H 'Content-type: application/json' \
+          --data "{\n            \"channel\": \"$CHANNEL\",\n            \"text\": \"⏳ Prod deployment awaiting approval for commit $COMMIT_SHA\",\n            \"attachments\": [{\n              \"text\": \"Approve deployment?\",\n              \"callback_id\": \"prod_approval\",\n              \"color\": \"#3AA3E3\",\n              \"actions\": [\n                {\"name\": \"approve\", \"text\": \"Approve ✅\", \"type\": \"button\", \"value\": \"approve_${GITHUB_SHA}\"},\n                {\"name\": \"reject\",  \"text\": \"Reject ❌\",  \"type\": \"button\", \"value\": \"reject_${GITHUB_SHA}\"}\n              ]\n            }]\n          }" https://slack.com/api/chat.postMessage

--- a/backend/api/alerts_ws.py
+++ b/backend/api/alerts_ws.py
@@ -1,4 +1,3 @@
-
 from fastapi import APIRouter, WebSocket, WebSocketDisconnect
 from typing import List
 import asyncio
@@ -9,12 +8,14 @@ active_connections: List[WebSocket] = []
 _broadcast_queue: asyncio.Queue | None = None
 _consumer_task: asyncio.Task | None = None
 
+
 async def _ensure_consumer():
     global _broadcast_queue, _consumer_task
     if _broadcast_queue is None:
         _broadcast_queue = asyncio.Queue()
     if _consumer_task is None or _consumer_task.done():
         _consumer_task = asyncio.create_task(_consumer())
+
 
 async def _consumer():
     while True:
@@ -25,13 +26,15 @@ async def _consumer():
                 await conn.send_json(message)
             except Exception:
                 stale.append(conn)
-        for s in stale:
-            if s in active_connections:
-                active_connections.remove(s)
+        for stale_conn in stale:
+            if stale_conn in active_connections:
+                active_connections.remove(stale_conn)
+
 
 async def broadcast(message: dict):
     await _ensure_consumer()
     await _broadcast_queue.put(message)
+
 
 def enqueue_alert(message: dict):
     """Thread-safe enqueue from sync contexts (e.g., DB calls)."""
@@ -39,15 +42,11 @@ def enqueue_alert(message: dict):
         loop = asyncio.get_running_loop()
         loop.create_task(broadcast(message))
     except RuntimeError:
-        # No running loop: try global loop via call_soon_threadsafe
-        loop = asyncio.new_event_loop()
-        loop.call_soon_threadsafe(lambda: None)
-        # Fallback: best-effort fire-and-forget using background task
         try:
             asyncio.run(broadcast(message))
         except RuntimeError:
-            # As a last resort, ignore (no event loop available)
             pass
+
 
 @router.websocket("")
 async def websocket_endpoint(websocket: WebSocket):
@@ -56,7 +55,7 @@ async def websocket_endpoint(websocket: WebSocket):
     await _ensure_consumer()
     try:
         while True:
-            await websocket.receive_text()  # keep alive
+            await websocket.receive_text()
     except WebSocketDisconnect:
         if websocket in active_connections:
             active_connections.remove(websocket)

--- a/backend/api/drive_diagnose.py
+++ b/backend/api/drive_diagnose.py
@@ -1,11 +1,7 @@
-from __future__ import annotations
-
 from fastapi import APIRouter
 
 router = APIRouter()
 
-
- codex/add-/projects/scan-drive-endpoint
 _STUBBED_DIAGNOSE_RESPONSE: dict[str, str] = {
     "status": "error",
     "detail": "Drive diagnostics are not available in the stubbed environment.",
@@ -24,14 +20,3 @@ def drive_diagnostics() -> dict[str, str]:
     """Backward-compatible alias for legacy clients."""
 
     return _STUBBED_DIAGNOSE_RESPONSE
-
-@router.get("/drive/diagnose")
-def drive_diagnose() -> dict[str, str]:
-    """Return a stubbed response representing drive diagnostics."""
-
-    return {
-        "status": "error",
-        "detail": "Drive diagnostics is not available in tests",
-    }
-      main
-

--- a/backend/services/vector_memory.py
+++ b/backend/services/vector_memory.py
@@ -3,15 +3,15 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Mapping, Option codex/update-project-handling-in-vector_memory
-_UNSET: Any = object(
-_DEFAULT_PROJECT: MutableMapping[str, Any] = {"id": None, "collection": None}
-_active_project: MutableMapping[str, Any] | None = Non.  main
+from typing import Any, Mapping, Optional
+
+_UNSET = object()
 
 
 @dataclass(frozen=True)
 class ActiveProject:
-    """Lightweight representation of the active project context. codex/update-project-handling-in-vector_memory
+    """Lightweight representation of the active project context."""
+
     id: Any | None = None
     collection: Any | None = None
 
@@ -27,18 +27,18 @@ def _coerce_to_active_project(
 ) -> ActiveProject:
     """Normalize different project representations into an :class:`ActiveProject`."""
 
-    id_value: Any | None = None
-    collection_value: Any | None | Any = _UNSET
-
     if isinstance(project, ActiveProject):
         id_value = project.id
         collection_value = project.collection
     elif isinstance(project, Mapping):
         id_value = project.get("id")
-        if "collection" in project:
-            collection_value = project.get("collection")
-    elif project is not None:
+        collection_value = project.get("collection")
+    elif project is None:
+        id_value = None
+        collection_value = None
+    else:
         id_value = project
+        collection_value = None
 
     if project_id is not None:
         id_value = project_id
@@ -46,23 +46,7 @@ def _coerce_to_active_project(
     if collection is not _UNSET:
         collection_value = collection
 
-    if collection_value is _UNSET:
-        collection_value = None
-
     return ActiveProject(id=id_value, collection=collection_value)
-    if project is None:
-        base: MutableMapping[str, Any] = {}
-    elif isinstance(project, Mapping):
-        base = dict(project)
-    else:
-        base = {"id": project}
-
-    normalized = dict(_DEFAULT_PROJECT)
-    normalized.update(base)
-    normalized.setdefault("id", None)
-    normalized.setdefault("collection", None)
-    return normalized
-         main
 
 
 def set_active_project(
@@ -71,44 +55,26 @@ def set_active_project(
     project_id: Optional[Any] = None,
     collection: Any = _UNSET,
 ) -> None:
-    """Persist the active project payload used by chat interactions.
-
-    The stored payload always exposes ``id`` and ``collection`` keys so that
-    downstream consumers can depend on a consistent structure. Callers may
-    provide the entire mapping or override individual fields via keyword
-    arguments. Invoking ``set_active_project()`` with no arguments resets the
-    payload to ``{"id": None, "collection": None}``.
-    """
+    """Persist the active project payload used by chat interactions."""
 
     global _active_project
 
     if project is None and project_id is None and collection is _UNSET:
         _active_project = None
         return
-        codex/update-project-handling-in-vector_memory
+
+    target = project if project is not None else ActiveProject()
     _active_project = _coerce_to_active_project(
-        project if project is not None else {},
+        target,
         project_id=project_id,
         collection=collection,
     )
-    
-     
-    normalized = _normalize_project(project)
-
-    if project_id is not None:
-        normalized["id"] = project_id
-
-    if collection is not None or "collection" not in normalized:
-        normalized["collection"] = collecti main
 
 
 def get_active_project() -> ActiveProject | None:
     """Return information about the active project."""
 
     return _active_project
-  codex/update-project-handling-in-vector_memory
-    if _active_project is None:
-        return dict(_DEFAULT_PROJECT)
-   main
+
 
 __all__ = ["ActiveProject", "get_active_project", "set_active_project"]

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "18.2.0",
-        "react-dom": "18.2.0"
+        "react-dom": "18.2.0",
+        "react-router-dom": "6.23.1"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "4.3.1",
@@ -803,6 +804,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.16.1.tgz",
+      "integrity": "sha512-es2g3dq6Nb07iFxGk5GuHN20RwBZOsuDQN7izWIisUcv9r+d2C5jQxqmgkdebXgReWfiyUabcki6Fg77mSNrig==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@types/babel__core": {
@@ -2072,6 +2082,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.23.1.tgz",
+      "integrity": "sha512-fzcOaRF69uvqbbM7OhvQyBTFDVrrGlsFdS3AL+1KfIBtGETibHzi3FkoTRyiDJnWNc2VxrfvR+657ROHjaNjqQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.16.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.23.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.23.1.tgz",
+      "integrity": "sha512-utP+K+aSTtEdbWpC+4gxhdlPFwuEfDKq8ZrPFU65bbRJY+l706qjR7yaidBpo3MSeA/fzwbXWbKBI6ftOnP3OQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.16.1",
+        "react-router": "6.23.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "18.2.0",
-    "react-dom": "18.2.0"
+    "react-dom": "18.2.0",
+    "react-router-dom": "6.23.1"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "4.3.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,50 +1,24 @@
-import React, { useState } from "react";
-import Sidebar from "./components/Sidebar";
-import Header from "./components/Header";
-import Chat from "./components/Chat";
-import Home from "./components/Home";
-import Help from "./components/Help";
-import Settings from "./components/Settings";
-import AdvancedIntelligence from "./pages/AdvancedIntelligence";
-import "./styles/theme.css";
-import "./styles/background.css";
+import React from "react";
+import { BrowserRouter as Router, Routes, Route } from "react-router-dom";
+import ChatWindow from "./components/ChatWindow";
+import AlertsPanel from "./components/AlertsPanel";
+import ProjectDashboard from "./components/ProjectDashboard";
 
 function App() {
-  const [activePage, setActivePage] = useState("home");
-  const [activeProject, setActiveProject] = useState("Villa 100");
-
-  const renderContent = () => {
-    if (activePage === "home") {
-      return <Home />;
-    }
-    if (activePage === "chat") {
-      return <Chat project={activeProject} />;
-    }
-    if (activePage === "help") {
-      return <Help />;
-    }
-    if (activePage === "settings") {
-      return <Settings />;
-    }
-    if (activePage === "intelligence") {
-      return <AdvancedIntelligence />;
-    }
-    return null;
-  };
-
   return (
-    <div className="chat-bg min-h-screen w-screen flex overflow-hidden">
-      <Sidebar
-        activePage={activePage}
-        onNavigate={setActivePage}
-        activeProject={activeProject}
-        onSelect={setActiveProject}
-      />
-      <div className="flex-1 flex flex-col">
-        <Header project={activeProject} activePage={activePage} />
-        <main className="flex-1 overflow-auto bg-white/80 backdrop-blur-sm">{renderContent()}</main>
+    <Router>
+      <div className="flex h-screen">
+        <div className="flex-1 border-r">
+          <Routes>
+            <Route path="/" element={<ChatWindow />} />
+            <Route path="/projects/:id" element={<ProjectDashboard />} />
+          </Routes>
+        </div>
+        <div className="w-96">
+          <AlertsPanel />
+        </div>
       </div>
-    </div>
+    </Router>
   );
 }
 

--- a/frontend/src/components/AlertsPanel.jsx
+++ b/frontend/src/components/AlertsPanel.jsx
@@ -1,1 +1,28 @@
-# Placeholder for frontend/src/components/AlertsPanel.jsx
+import React from "react";
+
+const mockAlerts = [
+  { id: 1, project: "Falcon", category: "deployment", message: "Prod deployment approved by Layla" },
+  { id: 2, project: "Qasr", category: "validation", message: "BoQ variance exceeds threshold" }
+];
+
+const AlertsPanel = () => {
+  return (
+    <aside className="flex h-full flex-col border-l bg-white">
+      <div className="border-b px-4 py-3">
+        <h2 className="text-base font-semibold text-gray-900">Live Alerts</h2>
+        <p className="text-xs text-gray-500">Updates are pushed from the approvals workflow.</p>
+      </div>
+      <div className="flex-1 overflow-auto px-4 py-3 space-y-3">
+        {mockAlerts.map((alert) => (
+          <div key={alert.id} className="rounded-md border border-amber-200 bg-amber-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-amber-700">{alert.category}</p>
+            <p className="text-sm text-gray-900">{alert.message}</p>
+            <p className="text-xs text-gray-500">Project {alert.project}</p>
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+};
+
+export default AlertsPanel;

--- a/frontend/src/components/ChatWindow.jsx
+++ b/frontend/src/components/ChatWindow.jsx
@@ -1,1 +1,43 @@
-# Placeholder for frontend/src/components/ChatWindow.jsx
+import React from "react";
+
+const sampleMessages = [
+  { id: 1, sender: "System", text: "Welcome to the Diriyah AI assistant." },
+  { id: 2, sender: "Analyst", text: "Share the latest progress for Project Falcon." },
+  { id: 3, sender: "Assistant", text: "Structural review is on track and BOQ alignment is green." }
+];
+
+const ChatWindow = () => {
+  return (
+    <div className="flex h-full flex-col bg-white">
+      <header className="border-b px-6 py-4">
+        <h1 className="text-lg font-semibold text-gray-900">Project Chat</h1>
+        <p className="text-sm text-gray-500">Collaborate with your delivery teams in real time.</p>
+      </header>
+      <main className="flex-1 space-y-4 overflow-auto px-6 py-4">
+        {sampleMessages.map((message) => (
+          <div key={message.id} className="rounded-lg border border-gray-200 bg-gray-50 p-3">
+            <p className="text-xs uppercase tracking-wide text-gray-500">{message.sender}</p>
+            <p className="text-sm text-gray-700">{message.text}</p>
+          </div>
+        ))}
+      </main>
+      <footer className="border-t bg-gray-50 px-6 py-4">
+        <div className="flex items-center gap-3">
+          <input
+            className="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-indigo-500 focus:outline-none"
+            placeholder="Type a message to your project team"
+            readOnly
+          />
+          <button
+            type="button"
+            className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm"
+          >
+            Send
+          </button>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default ChatWindow;

--- a/frontend/src/components/ProjectDashboard.jsx
+++ b/frontend/src/components/ProjectDashboard.jsx
@@ -1,1 +1,12 @@
-# Placeholder for frontend/src/components/ProjectDashboard.jsx
+import React from "react";
+
+const ProjectDashboard = () => {
+  return (
+    <div className="p-6 space-y-4">
+      <h1 className="text-xl font-semibold text-gray-900">Project Dashboard</h1>
+      <p className="text-gray-600">Select a project from the chat or alerts panel to view its health metrics.</p>
+    </div>
+  );
+};
+
+export default ProjectDashboard;

--- a/test_integration.py
+++ b/test_integration.py
@@ -1,0 +1,104 @@
+import hmac
+import hashlib
+import importlib
+import json
+from types import SimpleNamespace
+from urllib.parse import urlencode
+
+import pytest
+from fastapi.testclient import TestClient
+
+
+def _signature(secret: str, timestamp: str, body: str) -> str:
+    base = f"v0:{timestamp}:{body}"
+    digest = hmac.new(secret.encode(), base.encode(), hashlib.sha256).hexdigest()
+    return f"v0={digest}"
+
+
+@pytest.fixture
+def slack_test_app(monkeypatch, tmp_path):
+    monkeypatch.setenv("SLACK_SIGNING_SECRET", "signing-secret")
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "bot-token")
+    monkeypatch.setenv("GITHUB_TOKEN", "github-token")
+    monkeypatch.setenv("GITHUB_REPO", "example/repo")
+    monkeypatch.setenv("REQUIRED_APPROVALS", "1")
+    monkeypatch.setenv("DATABASE_URL", f"sqlite:///{tmp_path/'test.db'}")
+
+    module = importlib.import_module("backend.slack_webhook")
+    importlib.reload(module)
+
+    calls = []
+
+    class DummyResponse:
+        status_code = 200
+
+        def raise_for_status(self):
+            return None
+
+    def fake_post(url, headers=None, json=None, **kwargs):
+        calls.append({"url": url, "headers": headers, "json": json, "kwargs": kwargs})
+        return DummyResponse()
+
+    module.requests = SimpleNamespace(post=fake_post)
+    module.log_alert = lambda *args, **kwargs: None
+    module.log_approval = lambda *args, **kwargs: None
+
+    if module.APPROVAL_FILE.exists():
+        module.APPROVAL_FILE.unlink()
+
+    client = TestClient(module.app)
+
+    yield module, client, calls
+
+    if module.APPROVAL_FILE.exists():
+        module.APPROVAL_FILE.unlink()
+
+
+def test_slack_interactivity_triggers_workflow(slack_test_app):
+    module, client, calls = slack_test_app
+
+    payload = {
+        "user": {"name": "alice"},
+        "actions": [{"value": "approve_abc123"}],
+        "response_url": "https://hooks.slack.com/actions/123",
+        "channel": {"id": "C123"},
+        "message": {"ts": "1699999999.000100"},
+    }
+    body = urlencode({"payload": json.dumps(payload)})
+    timestamp = "1700000000"
+    signature = _signature("signing-secret", timestamp, body)
+
+    response = client.post(
+        "/slack/interactivity",
+        data=body,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-Slack-Signature": signature,
+            "X-Slack-Request-Timestamp": timestamp,
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    urls = [call["url"] for call in calls]
+    assert "https://slack.com/api/chat.postMessage" in urls
+    assert any(call["url"].startswith("https://api.github.com/repos/example/repo") for call in calls)
+    assert any(call["url"].startswith("https://hooks.slack.com/actions/") for call in calls)
+
+
+def test_validate_quantities_flags_mismatch():
+    from backend.validation import validate_quantities
+
+    cad_result = {"items": [{"name": "Concrete", "qty": 110}]} 
+    boq_result = {"Concrete": 100}
+
+    diffs = validate_quantities(cad_result, boq_result)
+
+    assert diffs == [
+        {
+            "item": "Concrete",
+            "cad": 110,
+            "boq": 100,
+            "flag": "Mismatch >5%",
+        }
+    ]


### PR DESCRIPTION
## Summary
- align backend alert broadcasting, Slack approval handling, and drive diagnostics stubs with the expected production-ready implementations
- add a CI workflow that runs pytest, lints the Helm chart, and posts Slack approval requests after successful main-branch pushes
- refresh the frontend shell to use react-router for the chat and project dashboard while keeping a dedicated alerts rail, and add coverage for Slack approvals plus quantity validation

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68dfc2356fd4832a84ad4704ebd04edd