### PR TITLE
Prepare Render deployment blueprint

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ cp .env.example .env
 docker compose up --build
 ```
 
+## Deploy to Render.com
+- Render automatically runs `render-build.sh` to install system dependencies, build the
+  frontend, and prepare the FastAPI app for production.
+- The backend service defined in `render.yaml` uses the generated virtual environment at
+  `/opt/render/project/.venv` and exposes the health check at `/health` for monitoring.
+
 ### Project Mode
 - Default **Fixture Mode** (no Google Drive): `USE_FIXTURE_PROJECTS=true`
 - Live Google Drive Mode: set `USE_FIXTURE_PROJECTS=false` (requires Drive creds)

--- a/render-build.sh
+++ b/render-build.sh
@@ -3,15 +3,20 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-# Install system packages required by the backend and frontend builds
-apt-get update \
-  && apt-get install -y --no-install-recommends \
-    ca-certificates \
-    curl \
-    libboost-all-dev \
-  && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
-  && apt-get install -y --no-install-recommends nodejs \
-  && rm -rf /var/lib/apt/lists/*
+# Install system packages required for building and running the app on Render
+apt-get update
+apt-get install -y --no-install-recommends \
+  build-essential \
+  ca-certificates \
+  curl \
+  libreoffice \
+  libmagic1 \
+  poppler-utils \
+  python3-venv \
+  tesseract-ocr
+curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+apt-get install -y --no-install-recommends nodejs
+rm -rf /var/lib/apt/lists/*
 
 # Install Python dependencies inside a virtual environment for Render debugging
 VENV_PATH="/opt/render/project/.venv"

--- a/render.yaml
+++ b/render.yaml
@@ -2,14 +2,14 @@
 services:
   - type: web
     name: mba-backend-main
-    env: docker
+    env: python
     plan: starter
+    region: oregon
     branch: main
-    buildCommand: >-
-      docker build -f backend/Dockerfile -t mba-backend .
+    buildCommand: ./render-build.sh
     startCommand: >-
-      bash -c "gunicorn -k uvicorn.workers.UvicornWorker -w 4 -b
-      0.0.0.0:8000 backend.main:app"
+      bash -c "source /opt/render/project/.venv/bin/activate &&
+      gunicorn -k uvicorn.workers.UvicornWorker -w 4 -b 0.0.0.0:8000 backend.main:app"
     envVars:
       - key: OPENAI_API_KEY
         sync: false
@@ -21,6 +21,7 @@ services:
         fromService:
           name: mba-redis
           property: connectionString
+    healthCheckPath: /health
   - type: redis
     name: mba-redis
     plan: starter


### PR DESCRIPTION
## Summary
- install the system packages, Python virtual environment, and frontend build within `render-build.sh`
- switch the Render blueprint to the native Python environment, invoke the build script, and expose the `/health` check
- document the Render deployment flow in the README

## Testing
- bash render-build.sh

------
https://chatgpt.com/codex/tasks/task_e_68e3a793c0ac832ab8079ba37eaf5b6e